### PR TITLE
Refactor of mesh.py

### DIFF
--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -1,6 +1,7 @@
 """
 Mesh using gmsh
 """
+from typing import Iterator
 
 import gmsh
 import numpy as np
@@ -9,65 +10,7 @@ from .phase import Phase
 from .rve import Rve
 
 _DIM_COUNT = 3
-
-
-def _generateListTags(listPhases: list[Phase]) -> list[list[int]]:
-    listTags: list[list[int]] = []
-    index: int = 0
-    for phase in listPhases:
-        temp: list[int] = []
-        for _ in phase.solids:
-            index += 1
-            temp.append(index)
-        listTags.append(temp)
-    return listTags
-
-
-def _mesh(
-        mesh_file: str,
-        listPhases: list[Phase],
-        order: int,
-        mshFileVersion: int = 4,
-) -> None:
-    gmsh.initialize()
-    gmsh.option.setNumber(
-        name="General.Verbosity", value=1
-    )  # this would still print errors, but not warnings
-
-    gmsh.model.mesh.setOrder(order=order)
-    gmsh.option.setNumber(name="Mesh.MshFileVersion", value=mshFileVersion)
-
-    flatListSolids = [solid for phase in listPhases for solid in phase.solids]
-    nbTags = len(flatListSolids)
-    flatListTags = list(range(1, nbTags + 1, 1))
-
-    listTags = _generateListTags(listPhases)
-
-    listDimTags = [(3, tag) for tag in flatListTags]
-
-    gmsh.model.occ.importShapes(fileName=mesh_file, highestDimOnly=True)
-
-    if len(listDimTags) > 1:
-        gmsh.model.occ.fragment(
-            objectDimTags=listDimTags[:-1], toolDimTags=[listDimTags[-1]]
-        )
-
-    gmsh.model.occ.synchronize()
-
-    for i, tag in enumerate(listTags):
-        ps_i = gmsh.model.addPhysicalGroup(dim=3, tags=tag)
-        gmsh.model.setPhysicalName(dim=3, tag=ps_i, name="Mat" + str(i))
-
-
-def _saveMesh(
-        size: float,
-        output_file: str = "Mesh.msh",
-) -> None:
-    p = gmsh.model.getEntities()
-    gmsh.model.mesh.setSize(dimTags=p, size=size)
-    gmsh.model.mesh.generate(dim=3)
-    gmsh.write(fileName=output_file)
-    gmsh.finalize()
+_Point3D = np.ndarray
 
 
 def mesh(
@@ -91,56 +34,8 @@ def mesh(
     .. _gmsh.model.mesh.setOrder(order): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L1688
     .. _gmsh.model.mesh.setSize(dimTags, size): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L3140
     """
-    _mesh(mesh_file, listPhases, order, mshFileVersion)
-    _saveMesh(size, output_file)
-
-
-def _meshPeriodic(rve: Rve) -> None:
-    for axis in range(3):
-        _processAxis(rve, axis)
-
-
-def _processAxis(rve: Rve, axis: int) -> None:
-    translation_matrix = np.eye(4)
-    translation_matrix[axis, 3] = rve.delta[axis]
-    translation = list(translation_matrix.flatten())
-
-    eps = 1.0e-3 * min(rve.delta)
-
-    minimum = np.zeros(_DIM_COUNT)
-    maximum = np.array(rve.delta)
-    maximum[axis] = 0.
-
-    smin = gmsh.model.getEntitiesInBoundingBox(
-        *minimum - eps,
-        *maximum + eps,
-        dim=2
-    )
-    for dim_min, tag_min in smin:
-        # Then we get the bounding box of each left surface
-        bounds_min = np.asarray(gmsh.model.getBoundingBox(
-            dim_min, tag_min
-        )).reshape((2, _DIM_COUNT))
-        bounds_min[:, axis] += 1
-        # We translate the bounding box to the right and look for surfaces inside
-        # it:
-        smax = gmsh.model.getEntitiesInBoundingBox(
-            *bounds_min[0] - eps,
-            *bounds_min[1] + eps,
-            dim=2,
-        )
-        # For all the matches, we compare the corresponding bounding boxes...
-        for dim_max, tag_max in smax:
-            bounds_max = np.asarray(gmsh.model.getBoundingBox(
-                dim_max, tag_max
-            )).reshape((2, _DIM_COUNT))
-            bounds_max[:, axis] -= 1
-
-            # ...and if they match, we apply the periodicity constraint
-            if (
-                    np.all(np.abs(np.subtract(bounds_max, bounds_min)) < eps)
-            ):
-                gmsh.model.mesh.setPeriodic(2, [tag_max], [tag_min], translation)
+    _init_mesh(mesh_file, listPhases, order, mshFileVersion)
+    _save_mesh(size, output_file)
 
 
 def meshPeriodic(
@@ -166,6 +61,109 @@ def meshPeriodic(
     .. _gmsh.model.mesh.setOrder(order): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L1688
     .. _gmsh.model.mesh.setSize(dimTags, size): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L3140
     """
-    _mesh(mesh_file, listPhases, order, mshFileVersion)
-    _meshPeriodic(rve)
-    _saveMesh(size, output_file)
+    _init_mesh(mesh_file, listPhases, order, mshFileVersion)
+    _compute_periodicity(rve)
+    _save_mesh(size, output_file)
+
+
+def _generate_list_tags(listPhases: list[Phase]) -> list[list[int]]:
+    listTags: list[list[int]] = []
+    index: int = 0
+    for phase in listPhases:
+        temp: list[int] = []
+        for _ in phase.solids:
+            index += 1
+            temp.append(index)
+        listTags.append(temp)
+    return listTags
+
+
+def _init_mesh(
+        mesh_file: str,
+        listPhases: list[Phase],
+        order: int,
+        mshFileVersion: int = 4,
+) -> None:
+    gmsh.initialize()
+    gmsh.option.setNumber(
+        name="General.Verbosity", value=1
+    )  # this would still print errors, but not warnings
+
+    gmsh.model.mesh.setOrder(order=order)
+    gmsh.option.setNumber(name="Mesh.MshFileVersion", value=mshFileVersion)
+
+    flatListSolids = [solid for phase in listPhases for solid in phase.solids]
+    nbTags = len(flatListSolids)
+    flatListTags = list(range(1, nbTags + 1, 1))
+
+    listTags = _generate_list_tags(listPhases)
+
+    listDimTags = [(3, tag) for tag in flatListTags]
+
+    gmsh.model.occ.importShapes(fileName=mesh_file, highestDimOnly=True)
+
+    if len(listDimTags) > 1:
+        gmsh.model.occ.fragment(
+            objectDimTags=listDimTags[:-1], toolDimTags=[listDimTags[-1]]
+        )
+
+    gmsh.model.occ.synchronize()
+
+    for i, tag in enumerate(listTags):
+        ps_i = gmsh.model.addPhysicalGroup(dim=3, tags=tag)
+        gmsh.model.setPhysicalName(dim=3, tag=ps_i, name="Mat" + str(i))
+
+
+def _save_mesh(
+        size: float,
+        output_file: str = "Mesh.msh",
+) -> None:
+    p = gmsh.model.getEntities()
+    gmsh.model.mesh.setSize(dimTags=p, size=size)
+    gmsh.model.mesh.generate(dim=3)
+    gmsh.write(fileName=output_file)
+    gmsh.finalize()
+
+
+def _compute_periodicity(rve: Rve) -> None:
+    for axis in range(3):
+        _compute_periodicity_on_axis(rve, axis)
+
+
+def _iter_bounding_boxes(minimum: _Point3D, maximum: _Point3D, eps: float) -> Iterator[tuple[np.ndarray, int]]:
+    entities: list[tuple[int, int]] = gmsh.model.getEntitiesInBoundingBox(
+        *np.subtract(minimum, eps),
+        *np.add(maximum, eps),
+        dim=2
+    )
+    for dim, tag in entities:
+        bounds = np.asarray(gmsh.model.getBoundingBox(
+            dim, tag
+        )).reshape((2, _DIM_COUNT))
+        yield bounds, tag
+
+
+def _compute_periodicity_on_axis(rve: Rve, axis: int) -> None:
+    translation_matrix = np.eye(4)
+    translation_matrix[axis, 3] = rve.delta[axis]
+    translation = list(translation_matrix.flatten())
+
+    eps = 1.0e-3 * min(rve.delta)
+
+    minimum = np.zeros(_DIM_COUNT)
+    maximum = np.array(rve.delta)
+    maximum[axis] = 0.
+
+    for bounds_min, tag_min in _iter_bounding_boxes(minimum, maximum, eps):
+        bounds_min[:, axis] += 1
+        for bounds_max, tag_max in _iter_bounding_boxes(bounds_min[0], bounds_min[1], eps):
+            bounds_max[:, axis] -= 1
+            if (
+                    np.all(np.abs(np.subtract(bounds_max, bounds_min)) < eps)
+            ):
+                gmsh.model.mesh.setPeriodic(
+                    dim=2,
+                    tags=[tag_max],
+                    tagsMaster=[tag_min],
+                    affineTransform=translation
+                )

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -8,28 +8,27 @@ import numpy as np
 from .phase import Phase
 from .rve import Rve
 
+_DIM_COUNT = 3
 
-def mesh(
-    mesh_file: str,
-    listPhases: list[Phase],
-    size: float,
-    order: int,
-    output_file: str = "Mesh.msh",
-    mshFileVersion: int = 4,
+
+def _generateListTags(listPhases: list[Phase]) -> list[list[int]]:
+    listTags: list[list[int]] = []
+    index: int = 0
+    for phase in listPhases:
+        temp: list[int] = []
+        for _ in phase.solids:
+            index += 1
+            temp.append(index)
+        listTags.append(temp)
+    return listTags
+
+
+def _mesh(
+        mesh_file: str,
+        listPhases: list[Phase],
+        order: int,
+        mshFileVersion: int = 4,
 ) -> None:
-    """
-    Meshes step file with gmsh with list of phases management
-
-    :param mesh_file: step file to mesh
-    :param listPhases: list of phases to mesh
-    :param size: mesh size constraint (see: `gmsh.model.mesh.setSize(dimTags, size)`_)
-    :param order: see `gmsh.model.mesh.setOrder(order)`_
-    :param output_file: output file (.msh, .vtk)
-    :param mshFileVersion: gmsh file version
-
-    .. _gmsh.model.mesh.setOrder(order): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L1688
-    .. _gmsh.model.mesh.setSize(dimTags, size): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L3140
-    """
     gmsh.initialize()
     gmsh.option.setNumber(
         name="General.Verbosity", value=1
@@ -40,18 +39,11 @@ def mesh(
 
     flatListSolids = [solid for phase in listPhases for solid in phase.solids]
     nbTags = len(flatListSolids)
-    FlatListTags = list(range(1, nbTags + 1, 1))
+    flatListTags = list(range(1, nbTags + 1, 1))
 
-    listTags = []
-    index = 0
-    for i, phase in enumerate(listPhases):
-        temp = []
-        for j, solid in enumerate(phase.solids):
-            index = index + 1
-            temp.append(index)
-        listTags.append(temp)
+    listTags = _generateListTags(listPhases)
 
-    listDimTags = [(3, tag) for tag in FlatListTags]
+    listDimTags = [(3, tag) for tag in flatListTags]
 
     gmsh.model.occ.importShapes(fileName=mesh_file, highestDimOnly=True)
 
@@ -66,22 +58,99 @@ def mesh(
         ps_i = gmsh.model.addPhysicalGroup(dim=3, tags=tag)
         gmsh.model.setPhysicalName(dim=3, tag=ps_i, name="Mat" + str(i))
 
-    p = gmsh.model.getEntities()
 
+def _saveMesh(
+        size: float,
+        output_file: str = "Mesh.msh",
+) -> None:
+    p = gmsh.model.getEntities()
     gmsh.model.mesh.setSize(dimTags=p, size=size)
     gmsh.model.mesh.generate(dim=3)
     gmsh.write(fileName=output_file)
     gmsh.finalize()
 
 
+def mesh(
+        mesh_file: str,
+        listPhases: list[Phase],
+        size: float,
+        order: int,
+        output_file: str = "Mesh.msh",
+        mshFileVersion: int = 4,
+) -> None:
+    """
+    Meshes step file with gmsh with list of phases management
+
+    :param mesh_file: step file to mesh
+    :param listPhases: list of phases to mesh
+    :param size: mesh size constraint (see: `gmsh.model.mesh.setSize(dimTags, size)`_)
+    :param order: see `gmsh.model.mesh.setOrder(order)`_
+    :param output_file: output file (.msh, .vtk)
+    :param mshFileVersion: gmsh file version
+
+    .. _gmsh.model.mesh.setOrder(order): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L1688
+    .. _gmsh.model.mesh.setSize(dimTags, size): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L3140
+    """
+    _mesh(mesh_file, listPhases, order, mshFileVersion)
+    _saveMesh(size, output_file)
+
+
+def _meshPeriodic(rve: Rve) -> None:
+    for axis in range(3):
+        _processAxis(rve, axis)
+
+
+def _processAxis(rve: Rve, axis: int) -> None:
+    translation_matrix = np.eye(4)
+    translation_matrix[axis, 3] = rve.delta[axis]
+    translation = list(translation_matrix.flatten())
+
+    eps = 1.0e-3 * min(rve.delta)
+
+    minimum = np.zeros(_DIM_COUNT)
+    maximum = np.array(rve.delta)
+    maximum[axis] = 0.
+
+    smin = gmsh.model.getEntitiesInBoundingBox(
+        *minimum - eps,
+        *maximum + eps,
+        dim=2
+    )
+    for dim_min, tag_min in smin:
+        # Then we get the bounding box of each left surface
+        bounds_min = np.asarray(gmsh.model.getBoundingBox(
+            dim_min, tag_min
+        )).reshape((2, _DIM_COUNT))
+        bounds_min[:, axis] += 1
+        # We translate the bounding box to the right and look for surfaces inside
+        # it:
+        smax = gmsh.model.getEntitiesInBoundingBox(
+            *bounds_min[0] - eps,
+            *bounds_min[1] + eps,
+            dim=2,
+        )
+        # For all the matches, we compare the corresponding bounding boxes...
+        for dim_max, tag_max in smax:
+            bounds_max = np.asarray(gmsh.model.getBoundingBox(
+                dim_max, tag_max
+            )).reshape((2, _DIM_COUNT))
+            bounds_max[:, axis] -= 1
+
+            # ...and if they match, we apply the periodicity constraint
+            if (
+                    np.all(np.abs(np.subtract(bounds_max, bounds_min)) < eps)
+            ):
+                gmsh.model.mesh.setPeriodic(2, [tag_max], [tag_min], translation)
+
+
 def meshPeriodic(
-    mesh_file: str,
-    rve: Rve,
-    listPhases: list[Phase],
-    size: float,
-    order: int,
-    output_file: str = "MeshPeriodic.msh",
-    mshFileVersion: int = 4,
+        mesh_file: str,
+        rve: Rve,
+        listPhases: list[Phase],
+        size: float,
+        order: int,
+        output_file: str = "MeshPeriodic.msh",
+        mshFileVersion: int = 4,
 ) -> None:
     """
     Meshes periodic geometries with gmsh
@@ -97,174 +166,6 @@ def meshPeriodic(
     .. _gmsh.model.mesh.setOrder(order): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L1688
     .. _gmsh.model.mesh.setSize(dimTags, size): https://gitlab.onelab.info/gmsh/gmsh/blob/master/api/gmsh.py#L3140
     """
-    gmsh.initialize()
-    gmsh.option.setNumber(
-        "General.Verbosity", 1
-    )  # this would still print errors, but not warnings
-
-    gmsh.model.mesh.setOrder(order)
-    gmsh.option.setNumber("Mesh.MshFileVersion", mshFileVersion)
-
-    flatListSolids = [solid for phase in listPhases for solid in phase.solids]
-    nbTags = len(flatListSolids)
-
-    flatListTags = list(range(1, nbTags + 1, 1))
-
-    listTags = []
-    index = 0
-    for i, phase in enumerate(listPhases):
-        temp = []
-        for j, solid in enumerate(phase.solids):
-            index = index + 1
-            temp.append(index)
-        listTags.append(temp)
-
-    listDimTags = [(3, tag) for tag in flatListTags]
-
-    gmsh.model.occ.importShapes(mesh_file, highestDimOnly=True)
-
-    size_box = np.min(np.array([rve.dx, rve.dy, rve.dz]))
-    eps = 1.0e-3 * size_box
-    if len(listDimTags) > 1:
-        outDimTags, outDimTagsMap = gmsh.model.occ.fragment(
-            listDimTags[:-1], [listDimTags[-1]]
-        )
-    gmsh.model.occ.synchronize()
-
-    for i, tag in enumerate(listTags):
-        ps_i = gmsh.model.addPhysicalGroup(3, tag)
-        gmsh.model.setPhysicalName(3, ps_i, "Mat" + str(i))
-
-    p = gmsh.model.getEntities()
-
-    # We now identify corresponding surfaces on the left and right sides of the
-    # geometry automatically.
-
-    # We get all the entities on the Xm
-    translation = [1, 0, 0, rve.dx, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
-    sxmin = gmsh.model.getEntitiesInBoundingBox(
-        0 - eps, -eps, -eps, eps, rve.dy + eps, rve.dy + eps, 2
-    )
-
-    for tup_min in sxmin:
-        # Then we get the bounding box of each left surface
-        xmin, ymin, zmin, xmax, ymax, zmax = gmsh.model.getBoundingBox(
-            tup_min[0], tup_min[1]
-        )
-        # We translate the bounding box to the right and look for surfaces inside
-        # it:
-        sxmax = gmsh.model.getEntitiesInBoundingBox(
-            xmin - eps + 1,
-            ymin - eps,
-            zmin - eps,
-            xmax + eps + 1,
-            ymax + eps,
-            zmax + eps,
-            2,
-        )
-        # For all the matches, we compare the corresponding bounding boxes...
-        for tup_max in sxmax:
-            xmin2, ymin2, zmin2, xmax2, ymax2, zmax2 = gmsh.model.getBoundingBox(
-                tup_max[0], tup_max[1]
-            )
-            xmin2 -= 1
-            xmax2 -= 1
-
-            # ...and if they match, we apply the periodicity constraint
-            if (
-                abs(xmin2 - xmin) < eps
-                and abs(xmax2 - xmax) < eps
-                and abs(ymin2 - ymin) < eps
-                and abs(ymax2 - ymax) < eps
-                and abs(zmin2 - zmin) < eps
-                and abs(zmax2 - zmax) < eps
-            ):
-                gmsh.model.mesh.setPeriodic(2, [tup_max[1]], [tup_min[1]], translation)
-
-    # We get all the entities on the Ym
-    translation = [1, 0, 0, 0, 0, 1, 0, rve.dy, 0, 0, 1, 0, 0, 0, 0, 1]
-    symin = gmsh.model.getEntitiesInBoundingBox(
-        0 - eps, -eps, -eps, rve.dx + eps, eps, rve.dz + eps, 2
-    )
-
-    for tup_min in symin:
-        # Then we get the bounding box of each left surface
-        xmin, ymin, zmin, xmax, ymax, zmax = gmsh.model.getBoundingBox(
-            tup_min[0], tup_min[1]
-        )
-        # We translate the bounding box to the right and look for surfaces inside
-        # it:
-        symax = gmsh.model.getEntitiesInBoundingBox(
-            xmin - eps,
-            ymin - eps + 1,
-            zmin - eps,
-            xmax + eps,
-            ymax + eps + 1,
-            zmax + eps,
-            2,
-        )
-        # For all the matches, we compare the corresponding bounding boxes...
-        for tup_max in symax:
-            xmin2, ymin2, zmin2, xmax2, ymax2, zmax2 = gmsh.model.getBoundingBox(
-                tup_max[0], tup_max[1]
-            )
-            ymin2 -= 1
-            ymax2 -= 1
-
-            # ...and if they match, we apply the periodicity constraint
-            if (
-                abs(xmin2 - xmin) < eps
-                and abs(xmax2 - xmax) < eps
-                and abs(ymin2 - ymin) < eps
-                and abs(ymax2 - ymax) < eps
-                and abs(zmin2 - zmin) < eps
-                and abs(zmax2 - zmax) < eps
-            ):
-                gmsh.model.mesh.setPeriodic(2, [tup_max[1]], [tup_min[1]], translation)
-
-    # We get all the entities on the Zm
-    translation = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, rve.dz, 0, 0, 0, 1]
-    szmin = gmsh.model.getEntitiesInBoundingBox(
-        0 - eps, -eps, -eps, rve.dx + eps, rve.dy + eps, eps, 2
-    )
-
-    for tup_min in szmin:
-        # Then we get the bounding box of each left surface
-        xmin, ymin, zmin, xmax, ymax, zmax = gmsh.model.getBoundingBox(
-            tup_min[0], tup_min[1]
-        )
-        # We translate the bounding box to the right and look for surfaces inside
-        # it:
-        szmax = gmsh.model.getEntitiesInBoundingBox(
-            xmin - eps,
-            ymin - eps,
-            zmin - eps + 1,
-            xmax + eps,
-            ymax + eps,
-            zmax + eps + 1,
-            2,
-        )
-        # For all the matches, we compare the corresponding bounding boxes...
-        for tup_max in szmax:
-            xmin2, ymin2, zmin2, xmax2, ymax2, zmax2 = gmsh.model.getBoundingBox(
-                tup_max[0], tup_max[1]
-            )
-            zmin2 -= 1
-            zmax2 -= 1
-
-            # ...and if they match, we apply the periodicity constraint
-            if (
-                abs(xmin2 - xmin) < eps
-                and abs(xmax2 - xmax) < eps
-                and abs(ymin2 - ymin) < eps
-                and abs(ymax2 - ymax) < eps
-                and abs(zmin2 - zmin) < eps
-                and abs(zmax2 - zmax) < eps
-            ):
-                gmsh.model.mesh.setPeriodic(2, [tup_max[1]], [tup_min[1]], translation)
-
-    p = gmsh.model.getEntities()
-    gmsh.model.mesh.setSize(p, size)
-    gmsh.model.mesh.generate(3)
-    gmsh.write(output_file)
-    gmsh.finalize()
+    _mesh(mesh_file, listPhases, order, mshFileVersion)
+    _meshPeriodic(rve)
+    _saveMesh(size, output_file)

--- a/microgen/rve.py
+++ b/microgen/rve.py
@@ -33,9 +33,10 @@ class Rve:
         self.y_max = center[1] + 0.5 * dim_y
         self.z_min = center[2] - 0.5 * dim_z
         self.z_max = center[2] + 0.5 * dim_z
-        self.dx = abs(self.x_max - self.x_min)
-        self.dy = abs(self.y_max - self.y_min)
-        self.dz = abs(self.z_max - self.z_min)
+        self.dx: float = abs(self.x_max - self.x_min)
+        self.dy: float = abs(self.y_max - self.y_min)
+        self.dz: float = abs(self.z_max - self.z_min)
+        self.delta = (self.dx, self.dy, self.dz)
         self.box = (
             cq.Workplane()
             .box(self.dim_x, self.dim_y, self.dim_z)

--- a/microgen/rve.py
+++ b/microgen/rve.py
@@ -36,7 +36,6 @@ class Rve:
         self.dx: float = abs(self.x_max - self.x_min)
         self.dy: float = abs(self.y_max - self.y_min)
         self.dz: float = abs(self.z_max - self.z_min)
-        self.delta = (self.dx, self.dy, self.dz)
         self.box = (
             cq.Workplane()
             .box(self.dim_x, self.dim_y, self.dim_z)

--- a/microgen/rve.py
+++ b/microgen/rve.py
@@ -33,9 +33,9 @@ class Rve:
         self.y_max = center[1] + 0.5 * dim_y
         self.z_min = center[2] - 0.5 * dim_z
         self.z_max = center[2] + 0.5 * dim_z
-        self.dx: float = abs(self.x_max - self.x_min)
-        self.dy: float = abs(self.y_max - self.y_min)
-        self.dz: float = abs(self.z_max - self.z_min)
+        self.dx = abs(self.x_max - self.x_min)
+        self.dy = abs(self.y_max - self.y_min)
+        self.dz = abs(self.z_max - self.z_min)
         self.box = (
             cq.Workplane()
             .box(self.dim_x, self.dim_y, self.dim_z)


### PR DESCRIPTION
This pull request proposes a refactor of the `mesh.py` file to remove the code duplication caused by the processing of the X, Y, Z axes, and to unify the parts in common between the processing of the standard and the periodic meshes.

> ⚠️ The fact that the code had a different behavior for the X axis at [this line of the `main` branch](https://github.com/3MAH/microgen/blob/main/microgen/mesh.py#L146) (the last `rve.dy` shouldn't be `rve.dz`?) has been considered a bug, and has been corrected.

No additionnal automatic tests have been added as I am not familiar with the topic, so this code should be tested carefully by an expert before being added to the codebase to make sure no regression has been introduced.