### PR TITLE
Refactor phase.py and operations.py

### DIFF
--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -2,14 +2,12 @@
 Boolean operations
 """
 
-import os
 from typing import Union, Tuple, List
 
+import OCP
 import cadquery as cq
 import numpy as np
 import pyvista as pv
-
-import OCP
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
 from OCP.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
 
@@ -311,26 +309,7 @@ def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq
 
     :return: cq shape of the repeated geometry
     """
-
-    center = unit_geom.Center()
-
-    xyz_repeat = cq.Assembly()
-    for i_x in range(grid[0]):
-        for i_y in range(grid[1]):
-            for i_z in range(grid[2]):
-                xyz_repeat.add(
-                    unit_geom,
-                    loc=cq.Location(
-                        cq.Vector(
-                            center.x - rve.dim_x * (0.5 * grid[0] - 0.5 - i_x),
-                            center.y - rve.dim_y * (0.5 * grid[1] - 0.5 - i_y),
-                            center.z - rve.dim_z * (0.5 * grid[2] - 0.5 - i_z),
-                        )
-                    ),
-                )
-    compound = xyz_repeat.toCompound()
-    shape = cq.Shape(compound.wrapped)
-    return shape
+    return Phase.repeatShape(unit_geom, rve, grid)
 
 
 def repeatPolyData(

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -106,25 +106,7 @@ def rescale(
 
     :return shape: rescaled Shape
     """
-    if isinstance(scale, float):
-        scale = (scale, scale, scale)
-
-    center = shape.Center()
-
-    # move the shape at (0, 0, 0) to rescale it
-    shape.move(cq.Location(cq.Vector(-center.x, -center.y, -center.z)))
-
-    # then move it back to its center with transform Matrix
-    transform_mat = cq.Matrix(
-        [
-            [scale[0], 0, 0, center.x],
-            [0, scale[1], 0, center.y],
-            [0, 0, scale[2], center.z],
-        ]
-    )
-    shape = shape.transformGeometry(transform_mat)
-
-    return shape
+    return Phase.rescaleShape(shape, scale)
 
 
 def fuseShapes(cqShapeList: List[cq.Shape], retain_edges: bool) -> cq.Shape:
@@ -295,7 +277,7 @@ def rasterPhase(
     solidList: list[cq.Solid] = phase.buildSolids(rve, grid)
 
     if phasePerRaster:
-        return Phase.generatePhasePerRaster(grid, rve, solidList)
+        return Phase.generatePhasePerRaster(solidList, rve, grid)
     return Phase(solids=solidList)
 
 

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -27,18 +27,19 @@ def rotateEuler(
 
     :param obj: Object to rotate
     :param center: numpy array (x, y, z)
-    :param psi: first Euler angle
-    :param theta: first Euler angle
-    :param phi: first Euler angle
+    :param psi: first Euler angle, in degrees
+    :param theta: first Euler angle, in degrees
+    :param phi: first Euler angle, in degrees
 
     :return object_r: Rotated object
     """
-    u = np.array([np.cos(psi * np.pi / 180.0), np.sin(psi * np.pi / 180.0), 0.0])
+    psi_rad, theta_rad, phi_rad = np.deg2rad((psi, theta, phi))
+    u = np.array([np.cos(psi_rad), np.sin(psi_rad), 0.0])
     z2 = np.array(
         [
-            np.sin(psi * np.pi / 180.0) * np.sin(theta * np.pi / 180.0),
-            -np.sin(theta * np.pi / 180.0) * np.cos(psi * np.pi / 180.0),
-            np.cos(theta * np.pi / 180.0),
+            np.sin(psi_rad) * np.sin(theta_rad),
+            -np.sin(theta_rad) * np.cos(psi_rad),
+            np.cos(theta_rad),
         ]
     )
 
@@ -72,9 +73,9 @@ def rotatePvEuler(
 
     :param obj: Object to rotate
     :param center: numpy array (x, y, z)
-    :param psi: first Euler angle
-    :param theta: second Euler angle
-    :param phi: third Euler angle
+    :param psi: first Euler angle, in degrees
+    :param theta: second Euler angle, in degrees
+    :param phi: third Euler angle, in degrees
     :return: Rotated object
     """
 

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -55,16 +55,12 @@ def rotateEuler(
     :param theta: first Euler angle, in degrees
     :param phi: first Euler angle, in degrees
 
-    :return object_r: Rotated object
+    :return: Rotated object
     """
-
     center_vector = cq.Vector(*center)
-
     z, u, z2 = _getRotationAxes(psi, theta, phi)
-
-    obj = obj.rotate(center_vector, center_vector + cq.Vector(*z), psi)
-    obj = obj.rotate(center_vector, center_vector + cq.Vector(*u), theta)
-    obj = obj.rotate(center_vector, center_vector + cq.Vector(*z2), phi)
+    for axis, angle in zip((z, u, z2), (psi, theta, phi)):
+        obj = obj.rotate(center_vector, center_vector + cq.Vector(*axis), angle)
     return obj
 
 
@@ -88,12 +84,12 @@ def rotatePvEuler(
     """
     z, u, z2 = _getRotationAxes(psi, theta, phi)
 
-    object_r = obj.rotate_vector(
+    rotated_obj = obj.rotate_vector(
         vector=z, angle=psi, point=tuple(center), inplace=False
     )
-    object_r.rotate_vector(vector=u, angle=theta, point=tuple(center), inplace=True)
-    object_r.rotate_vector(vector=z2, angle=phi, point=tuple(center), inplace=True)
-    return object_r
+    rotated_obj.rotate_vector(vector=u, angle=theta, point=tuple(center), inplace=True)
+    rotated_obj.rotate_vector(vector=z2, angle=phi, point=tuple(center), inplace=True)
+    return rotated_obj
 
 
 def rescale(

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -27,12 +27,12 @@ def rotateEuler(
 
     :param obj: Object to rotate
     :param center: numpy array (x, y, z)
-    :param psi, theta, phi: Euler angles
+    :param psi: first Euler angle
+    :param theta: first Euler angle
+    :param phi: first Euler angle
 
     :return object_r: Rotated object
     """
-
-    u = np.array([0.0, 0.0, 1.0])
     u = np.array([np.cos(psi * np.pi / 180.0), np.sin(psi * np.pi / 180.0), 0.0])
     z2 = np.array(
         [
@@ -61,7 +61,7 @@ def rotateEuler(
 
 
 def rotatePvEuler(
-    object: pv.PolyData,
+    obj: pv.PolyData,
     center: np.ndarray,
     psi: float,
     theta: float,
@@ -70,24 +70,17 @@ def rotatePvEuler(
     """
     Rotates object according to XZX Euler angle convention
 
-    Parameters
-    ----------
-    object :
-        Object to rotate
-    center :
-        numpy array (x, y, z)
-    psi, theta, phi :
-        Euler angles
-
-    Returns
-    -------
-    object_r :
-        Rotated object
+    :param obj: Object to rotate
+    :param center: numpy array (x, y, z)
+    :param psi: first Euler angle
+    :param theta: second Euler angle
+    :param phi: third Euler angle
+    :return: Rotated object
     """
 
     u = (np.cos(psi), np.sin(psi), 0.0)
     z2 = (np.sin(psi) * np.sin(theta), -np.sin(theta) * np.cos(psi), np.cos(theta))
-    object_r = object.rotate_vector(
+    object_r = obj.rotate_vector(
         vector=(0, 0, 1), angle=psi, point=tuple(center), inplace=False
     )
     object_r.rotate_vector(vector=u, angle=theta, point=tuple(center), inplace=True)

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -294,43 +294,11 @@ def rasterPhase(
 
     :return: Phase or list of Phases
     """
-    solidList = []  # type: list[cq.Solid]
-
-    for solid in phase.solids:
-        wk_plane = cq.Workplane().add(solid)
-        xgrid = np.linspace(rve.x_min, rve.x_max, num=grid[0])
-        ygrid = np.linspace(rve.y_min, rve.y_max, num=grid[1])
-        zgrid = np.linspace(rve.z_min, rve.z_max, num=grid[2])
-        np.delete(xgrid, 0)
-        np.delete(ygrid, 0)
-        np.delete(zgrid, 0)
-        for i in xgrid:
-            Plane_x = cq.Face.makePlane(basePnt=(i, 0, 0), dir=(1, 0, 0))
-            wk_plane = wk_plane.split(cq.Workplane().add(Plane_x))
-        for j in ygrid:
-            Plane_y = cq.Face.makePlane(basePnt=(0, j, 0), dir=(0, 1, 0))
-            wk_plane = wk_plane.split(cq.Workplane().add(Plane_y))
-        for k in zgrid:
-            Plane_z = cq.Face.makePlane(basePnt=(0, 0, k), dir=(0, 0, 1))
-            wk_plane = wk_plane.split(cq.Workplane().add(Plane_z))
-
-        for subsolid in wk_plane.val().Solids():
-            solidList.append(subsolid)
+    solidList: list[cq.Solid] = phase.buildSolids(rve, grid)
 
     if phasePerRaster:
-        solids_phases = [
-            [] for _ in range(grid[0] * grid[1] * grid[2])
-        ]  # type: list[list[cq.Solid]]
-        for solid in solidList:
-            center = solid.Center()
-            i = int(round((center.x - rve.x_min) / (rve.dx / grid[0])))
-            j = int(round((center.y - rve.y_min) / (rve.dy / grid[1])))
-            k = int(round((center.z - rve.z_min) / (rve.dz / grid[2])))
-            ind = i + grid[0] * j + grid[0] * grid[1] * k
-            solids_phases[ind].append(solid)
-        return [Phase(solids=solids) for solids in solids_phases if len(solids) > 0]
-    else:
-        return Phase(solids=solidList)
+        return Phase.generatePhasePerRaster(grid, rve, solidList)
+    return Phase(solids=solidList)
 
 
 def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq.Shape:

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -27,19 +27,19 @@ class Phase:
 
     def __init__(
         self,
-        shape: cq.Shape = None,
+        shape: Optional[cq.Shape] = None,
         solids: Optional[list[cq.Solid]] = None,
         center: Optional[tuple[float, float, float]] = None,
         orientation: Optional[tuple[float, float, float]] = None,
     ) -> None:
 
-        if shape is None and solids == []:
-            print("Empty phase")
-
         self._shape = shape
-        self._solids = solids if solids is not None else []
+        self._solids: list[cq.Solid] = solids if solids is not None else []
         self.center = center
         self.orientation = orientation
+
+        if shape is None and solids == []:
+            print("Empty phase")
 
         self.name = "Phase_" + str(self.numInstances)
 
@@ -105,7 +105,7 @@ class Phase:
         if self._shape is not None:
             return self._shape
         elif len(self._solids) > 0:
-            # there may be a fastest way
+            # there may be a faster way
             compound = cq.Compound.makeCompound(self._solids)
             self._shape = cq.Shape(compound.wrapped)
             return self._shape

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -2,7 +2,7 @@
 Phase class to manage list of solids belonging to the same phase
 """
 
-from typing import Union, Tuple, Optional
+from typing import Sequence, Optional, Union
 
 import cadquery as cq
 import numpy as np
@@ -29,8 +29,8 @@ class Phase:
         self,
         shape: cq.Shape = None,
         solids: Optional[list[cq.Solid]] = None,
-        center: tuple[float, float, float] = None,
-        orientation: tuple[float, float, float] = None,
+        center: Optional[tuple[float, float, float]] = None,
+        orientation: Optional[tuple[float, float, float]] = None,
     ) -> None:
 
         if shape is None and solids == []:
@@ -61,7 +61,7 @@ class Phase:
 
     centerOfMass = property(getCenterOfMass)
 
-    def _computeCenterOfMass(self):
+    def _computeCenterOfMass(self) -> None:
         """
         Calculates the center of 'mass' of an object.
         """
@@ -84,7 +84,7 @@ class Phase:
 
     inertiaMatrix = property(getInertiaMatrix)
 
-    def _computeInertiaMatrix(self):
+    def _computeInertiaMatrix(self) -> None:
         """
         Calculates the inertia Matrix of an object.
         """
@@ -101,7 +101,7 @@ class Phase:
         )
 
     @property
-    def shape(self) -> Union[cq.Shape, None]:
+    def shape(self) -> Optional[cq.Shape]:
         if self._shape is not None:
             return self._shape
         elif len(self._solids) > 0:
@@ -124,11 +124,8 @@ class Phase:
             print("No solids or shape")
             return []
 
-    def translate(self, vec: Union[tuple, np.ndarray]) -> None:
-        if type(vec) == tuple:
-            self._shape.move(cq.Location(cq.Vector(vec)))
-        else:
-            self._shape.move(cq.Location(cq.Vector(vec[0], vec[1], vec[2])))
+    def translate(self, vec: Sequence[float]) -> None:
+        self._shape.move(cq.Location(cq.Vector(*vec)))
         self._computeCenterOfMass()
 
     @staticmethod
@@ -173,7 +170,7 @@ class Phase:
 
     @staticmethod
     def repeatShape(
-        unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]
+        unit_geom: cq.Shape, rve: Rve, grid: tuple[int, int, int]
     ) -> cq.Shape:
         """
         Repeats unit geometry in each direction according to the given grid
@@ -205,7 +202,7 @@ class Phase:
         shape = cq.Shape(compound.wrapped)
         return shape
 
-    def repeat(self, rve: Rve, grid: Tuple[int, int, int]):
+    def repeat(self, rve: Rve, grid: tuple[int, int, int]) -> None:
         """
         Repeats phase in each direction according to the given grid
 

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -155,22 +155,26 @@ class Phase:
         )
         self._shape = self._shape.transformGeometry(transform_mat)
 
-    def repeat(self, rve: Rve, grid: Tuple[int, int, int]):
+    @staticmethod
+    def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq.Shape:
         """
-        Repeats phase in each direction according to the given grid
+        Repeats unit geometry in each direction according to the given grid
 
-        :param rve: RVE of the phase to repeat
-        :param grid: list of number of phase repetitions in each direction
+        :param unit_geom: Shape to repeat
+        :param rve: RVE of the geometry to repeat
+        :param grid: list of number of geometry repetitions in each direction
+
+        :return: cq shape of the repeated geometry
         """
 
-        center = self.shape.Center()
+        center = unit_geom.Center()
 
         xyz_repeat = cq.Assembly()
         for i_x in range(grid[0]):
             for i_y in range(grid[1]):
                 for i_z in range(grid[2]):
                     xyz_repeat.add(
-                        self.shape,
+                        unit_geom,
                         loc=cq.Location(
                             cq.Vector(
                                 center.x - rve.dim_x * (0.5 * grid[0] - 0.5 - i_x),
@@ -180,7 +184,17 @@ class Phase:
                         ),
                     )
         compound = xyz_repeat.toCompound()
-        self._shape = cq.Shape(compound.wrapped)
+        shape = cq.Shape(compound.wrapped)
+        return shape
+
+    def repeat(self, rve: Rve, grid: Tuple[int, int, int]):
+        """
+        Repeats phase in each direction according to the given grid
+
+        :param rve: RVE of the phase to repeat
+        :param grid: list of number of phase repetitions in each direction
+        """
+        self._shape = self.repeatShape(self.shape, rve, grid)
 
     def buildSolids(self, rve: Rve, grid: list[int]) -> list[cq.Solid]:
         """
@@ -234,6 +248,7 @@ class Phase:
         self._solids = solidList
         compound = cq.Compound.makeCompound(self._solids)
         self._shape = cq.Shape(compound.wrapped)
+        return None
 
     @staticmethod
     def generatePhasePerRaster(grid, rve, solidList):


### PR DESCRIPTION
# Description

I noticed some code duplication between `phase.py` and  `operations.py`, and decided to refactor out these two files.

# Changes

## Removed code duplication between:
- `operations.rasterPhase` and `Phase.rasterize`.
- `operations.repeatShape` and `Phase.repeat`.
- `operations.rescale` and `Phase.rescale`.
- `operations.rotateEuler` and `operations.rotatePvEuler`.

## Fixed:
- Bug in `operations.rotatePvEuler` where angles in degrees were sent to the *numpy* trigonometric functions, which expect radians.