### PR TITLE
Feature remesh keeping periodicity

### DIFF
--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -1,0 +1,119 @@
+import gmsh
+import numpy as np
+import math as m
+
+# Remeshing while preserving mesh periodicity
+
+def remesh_periodic(mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
+) -> None:
+    """
+    Prepares the mesh file for periodic remeshing
+
+    :param mesh_file: mesh file to remesh
+    :param rve: RVE for periodicity
+    :param output_file: output file (must be .mesh)
+    """
+
+    # Read mesh
+
+    gmsh.initialize()
+    gmsh.open(mesh_file)
+
+    ntets = len(gmsh.model.mesh.getElements(3)[1][0])
+
+    gmsh.model.mesh.createTopology() # Creates boundary entities
+
+    boundarySurface = gmsh.model.getEntities(2)
+    boundaryElementsType, boundaryElementsTags, boundaryElementsNodes = gmsh.model.mesh.getElements(2)
+    boundaryElementsNodesCoords = np.zeros((len(boundaryElementsNodes[0]), 3))
+
+    for i in range(len(boundaryElementsNodes[0])):
+        boundaryElementsNodesCoords[i] = gmsh.model.mesh.getNode(boundaryElementsNodes[0][i])[0]
+
+    # Find and keep only boundary elements (here, triangles) that are on the boundary of the rve
+
+    def computeNormal(node1Coords, node2Coords, node3Coords):
+        """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
+        u = node2Coords-node1Coords
+        v = node3Coords-node1Coords
+        n = np.cross(u,v)
+        normal = n/np.linalg.norm(n)
+        return normal
+
+    def isxmin(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on xmin boundary of a rve"""
+        xmin = rve.xmin
+        xminNormal = np.array([-1.0, 0.0, 0.0])
+        if m.isclose(node1Coords[0], xmin) and m.isclose(node2Coords[0], xmin) and m.isclose(node3Coords[0], xmin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), xminNormal):
+            return True
+        return False
+
+    def isxmax(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on xmax boundary of a rve"""
+        xmax = rve.xmax
+        xmaxNormal = np.array([1.0, 0.0, 0.0])
+        if m.isclose(node1Coords[0], xmax) and m.isclose(node2Coords[0], xmax) and m.isclose(node3Coords[0], xmax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), xmaxNormal):
+            return True
+        return False
+
+    def isymin(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on ymin boundary of a rve"""
+        ymin = rve.ymin
+        yminNormal = np.array([0.0, -1.0, 0.0])
+        if m.isclose(node1Coords[1], ymin) and m.isclose(node2Coords[1], ymin) and m.isclose(node3Coords[1], ymin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), yminNormal):
+            return True
+        return False
+
+    def isymax(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on ymax boundary of a rve"""
+        ymax = rve.ymax
+        ymaxNormal = np.array([0.0, 1.0, 0.0])
+        if m.isclose(node1Coords[1], ymax) and m.isclose(node2Coords[1], ymax) and m.isclose(node3Coords[1], ymax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), ymaxNormal):
+            return True
+        return False
+
+    def iszmin(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on zmin boundary of a rve"""
+        zmin = rve.zmin
+        zminNormal = np.array([0.0, 0.0, -1.0])
+        if m.isclose(node1Coords[2], zmin) and m.isclose(node2Coords[2], zmin) and m.isclose(node3Coords[2], zmin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), zminNormal):
+            return True
+        return False
+
+    def iszmax(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on zmax boundary of a rve"""
+        zmax = rve.zmax
+        zmaxNormal = np.array([0.0, 0.0, 1.0])
+        if m.isclose(node1Coords[2], zmax) and m.isclose(node2Coords[2], zmax) and m.isclose(node3Coords[2], zmax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), zmaxNormal):
+            return True
+        return False
+
+    def isboundary(node1Coords, node2Coords, node3Coords, rve):
+        """Determines whether a triangle (defined by its 3 nodes) is on the boundary on a rve"""
+        if isxmin(node1Coords, node2Coords, node3Coords, rve) or isxmax(node1Coords, node2Coords, node3Coords, rve) or isymin(node1Coords, node2Coords, node3Coords, rve) or isymax(node1Coords, node2Coords, node3Coords, rve) or iszmin(node1Coords, node2Coords, node3Coords, rve) or iszmax(node1Coords, node2Coords, node3Coords, rve):
+            return True
+        return False
+
+    boundaryElementsTagsToKeep = []
+    for i in range(len(boundaryElementsTags[0])):
+        if isboundary(boundaryElementsNodesCoords[3*i], boundaryElementsNodesCoords[3*i + 1], boundaryElementsNodesCoords[3*i + 2], rve):
+            boundaryElementsTagsToKeep.append(int(boundaryElementsTags[0][i] - ntets))
+
+    nTagsToKeep = len(boundaryElementsTagsToKeep)
+
+    # write files
+
+    gmsh.write(mesh_file[:-5] + "_triangles.mesh")
+    gmsh.finalize()
+
+    with open(mesh_file[:-5] + "_triangles.mesh", "r") as file:
+        lines = file.readlines()
+
+    with open(output_file, "w+") as outfile:
+        outfile.writelines(lines[:-1])
+        outfile.write('RequiredTriangles\n')
+        outfile.write(str(nTagsToKeep) + '\n')
+        for tag in boundaryElementsTagsToKeep:
+            outfile.write(str(tag) + '\n')
+        outfile.write('End\n')
+

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -2,27 +2,41 @@ import gmsh
 from microgen import Rve, Mmg
 import numpy as np
 import math as m
-from collections import namedtuple
 from tempfile import NamedTemporaryFile
 
-Triangle = namedtuple("Triangle", ["node1", "node2", "node3", "tag"])
+from typing import NamedTuple
+import numpy.typing as npt
+
+
+class Triangle(NamedTuple):
+    node1: npt.NDArray[np.float_]
+    node2: npt.NDArray[np.float_]
+    node3: npt.NDArray[np.float_]
+    tag: int
 
 _MESH_DIM = 3
 _BOUNDARY_DIM = 2
 
 
 def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
-                               output_mesh_file: str, hausd=None,
-                               hgrad=None,
-                               hmax=None,
-                               hmin=None,
-                               hsiz=None) -> None:
+                               output_mesh_file: str, hausd: float = None,
+                               hgrad: float = None,
+                               hmax: float = None,
+                               hmin: float = None,
+                               hsiz: float = None) -> None:
     """
     Remeshes a mesh (.mesh file format) using mmg while keeping periodicity
 
     :param input_mesh_file: mesh file to remesh (must be .mesh)
     :param rve: Representative Volume Element for periodicity
     :param output_mesh_file: output file (must be .mesh)
+
+    The following parameters are used to control mmg remeshing, see here for more info : https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options
+    :param hausd: Maximal Hausdorff distance for the boundaries approximation
+    :param hgrad: Gradation value, ie ratio between lengths of adjacent mesh edges
+    :param hmax: Maximal edge size
+    :param hmin: Minimal edge size
+    :param hsiz: Build a constant size map of size hsiz
     """
     with NamedTemporaryFile(suffix='.mesh') as boundary_triangles_file:
         _identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -1,10 +1,17 @@
 import gmsh
+from microgen import Rve
 import numpy as np
 import math as m
+from collections import namedtuple
 
-# Remeshing while preserving mesh periodicity
+Triangle = namedtuple("Triangle", ["node1", "node2", "node3", "tag"])
 
-def remesh_periodic(mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
+_MESH_DIM = 3
+_BOUNDARY_DIM = 2
+
+
+def remesh_periodic(
+    mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
 ) -> None:
     """
     Prepares the mesh file for periodic remeshing
@@ -13,95 +20,33 @@ def remesh_periodic(mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.me
     :param rve: RVE for periodicity
     :param output_file: output file (must be .mesh)
     """
-
-    # Read mesh
-
     gmsh.initialize()
     gmsh.open(mesh_file)
 
-    ntets = len(gmsh.model.mesh.getElements(3)[1][0])
+    gmsh.model.mesh.createTopology()  # Creates boundary entities
 
-    gmsh.model.mesh.createTopology() # Creates boundary entities
+    # Encapsulate this block into a private function
+    (
+        _,
+        surface_triangles_tags,
+        surface_triangles_nodes_tags,
+    ) = gmsh.model.mesh.getElements(_BOUNDARY_DIM)
+    surface_triangles_nodes_tags: list[int] = list(surface_triangles_nodes_tags[0])
+    surface_triangles_tags: list[int] = list(surface_triangles_tags[0])
+    #####
 
-    boundarySurface = gmsh.model.getEntities(2)
-    boundaryElementsType, boundaryElementsTags, boundaryElementsNodes = gmsh.model.mesh.getElements(2)
-    boundaryElementsNodesCoords = np.zeros((len(boundaryElementsNodes[0]), 3))
+    surface_triangles_nodes_coords = _get_surface_nodes_coords(
+        surface_triangles_nodes_tags
+    )
 
-    for i in range(len(boundaryElementsNodes[0])):
-        boundaryElementsNodesCoords[i] = gmsh.model.mesh.getNode(boundaryElementsNodes[0][i])[0]
+    surface_triangles = _build_surface_triangles(
+        surface_triangles_tags, surface_triangles_nodes_coords
+    )
+    boundary_triangles_tags = _extract_boundary_triangles_tags(surface_triangles, rve)
 
-    # Find and keep only boundary elements (here, triangles) that are on the boundary of the rve
+    n_boundary_triangles = len(boundary_triangles_tags)
 
-    def computeNormal(node1Coords, node2Coords, node3Coords):
-        """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
-        u = node2Coords-node1Coords
-        v = node3Coords-node1Coords
-        n = np.cross(u,v)
-        normal = n/np.linalg.norm(n)
-        return normal
-
-    def isxmin(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on xmin boundary of a rve"""
-        xmin = rve.xmin
-        xminNormal = np.array([-1.0, 0.0, 0.0])
-        if m.isclose(node1Coords[0], xmin) and m.isclose(node2Coords[0], xmin) and m.isclose(node3Coords[0], xmin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), xminNormal):
-            return True
-        return False
-
-    def isxmax(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on xmax boundary of a rve"""
-        xmax = rve.xmax
-        xmaxNormal = np.array([1.0, 0.0, 0.0])
-        if m.isclose(node1Coords[0], xmax) and m.isclose(node2Coords[0], xmax) and m.isclose(node3Coords[0], xmax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), xmaxNormal):
-            return True
-        return False
-
-    def isymin(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on ymin boundary of a rve"""
-        ymin = rve.ymin
-        yminNormal = np.array([0.0, -1.0, 0.0])
-        if m.isclose(node1Coords[1], ymin) and m.isclose(node2Coords[1], ymin) and m.isclose(node3Coords[1], ymin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), yminNormal):
-            return True
-        return False
-
-    def isymax(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on ymax boundary of a rve"""
-        ymax = rve.ymax
-        ymaxNormal = np.array([0.0, 1.0, 0.0])
-        if m.isclose(node1Coords[1], ymax) and m.isclose(node2Coords[1], ymax) and m.isclose(node3Coords[1], ymax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), ymaxNormal):
-            return True
-        return False
-
-    def iszmin(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on zmin boundary of a rve"""
-        zmin = rve.zmin
-        zminNormal = np.array([0.0, 0.0, -1.0])
-        if m.isclose(node1Coords[2], zmin) and m.isclose(node2Coords[2], zmin) and m.isclose(node3Coords[2], zmin) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), zminNormal):
-            return True
-        return False
-
-    def iszmax(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on zmax boundary of a rve"""
-        zmax = rve.zmax
-        zmaxNormal = np.array([0.0, 0.0, 1.0])
-        if m.isclose(node1Coords[2], zmax) and m.isclose(node2Coords[2], zmax) and m.isclose(node3Coords[2], zmax) and np.allclose(computeNormal(node1Coords, node2Coords, node3Coords), zmaxNormal):
-            return True
-        return False
-
-    def isboundary(node1Coords, node2Coords, node3Coords, rve):
-        """Determines whether a triangle (defined by its 3 nodes) is on the boundary on a rve"""
-        if isxmin(node1Coords, node2Coords, node3Coords, rve) or isxmax(node1Coords, node2Coords, node3Coords, rve) or isymin(node1Coords, node2Coords, node3Coords, rve) or isymax(node1Coords, node2Coords, node3Coords, rve) or iszmin(node1Coords, node2Coords, node3Coords, rve) or iszmax(node1Coords, node2Coords, node3Coords, rve):
-            return True
-        return False
-
-    boundaryElementsTagsToKeep = []
-    for i in range(len(boundaryElementsTags[0])):
-        if isboundary(boundaryElementsNodesCoords[3*i], boundaryElementsNodesCoords[3*i + 1], boundaryElementsNodesCoords[3*i + 2], rve):
-            boundaryElementsTagsToKeep.append(int(boundaryElementsTags[0][i] - ntets))
-
-    nTagsToKeep = len(boundaryElementsTagsToKeep)
-
-    # write files
+    # write files (there must be a more efficient way)
 
     gmsh.write(mesh_file[:-5] + "_triangles.mesh")
     gmsh.finalize()
@@ -111,9 +56,111 @@ def remesh_periodic(mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.me
 
     with open(output_file, "w+") as outfile:
         outfile.writelines(lines[:-1])
-        outfile.write('RequiredTriangles\n')
-        outfile.write(str(nTagsToKeep) + '\n')
-        for tag in boundaryElementsTagsToKeep:
-            outfile.write(str(tag) + '\n')
-        outfile.write('End\n')
+        outfile.write("RequiredTriangles\n")
+        outfile.write(str(n_boundary_triangles) + "\n")
+        for tag in boundary_triangles_tags:
+            outfile.write(str(tag) + "\n")
+        outfile.write("End\n")
 
+
+def _build_surface_triangles(
+    surface_triangles_tags: list[int], surface_triangles_nodes_coords: np.ndarray
+) -> list[Triangle]:
+    n_triangles = len(surface_triangles_tags)
+    surface_triangles = [
+        Triangle(
+            surface_triangles_nodes_coords[_MESH_DIM * i],
+            surface_triangles_nodes_coords[_MESH_DIM * i + 1],
+            surface_triangles_nodes_coords[_MESH_DIM * i + 2],
+            surface_triangles_tags[i],
+        )
+        for i in range(n_triangles)
+    ]
+    return surface_triangles
+
+
+def _compute_normal(triangle: Triangle) -> np.ndarray:
+    """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
+    u = triangle.node2 - triangle.node1
+    v = triangle.node3 - triangle.node1
+    n = np.cross(u, v)
+    normal = n / np.linalg.norm(n)
+    return normal
+
+
+def _get_surface_nodes_coords(surface_nodes: list[int]) -> np.ndarray:
+    n_nodes = len(surface_nodes)
+    surface_nodes_coords = np.zeros((n_nodes, _MESH_DIM))
+    for i in range(n_nodes):
+        surface_nodes_coords[i] = gmsh.model.mesh.getNode(surface_nodes[i])[0]
+    return surface_nodes_coords
+
+
+def _is_triangle_on_boundary(triangle: Triangle, rve: Rve) -> bool:
+    """Determines whether a triangle (defined by its 3 nodes) is on the boundary of a parallelepipedic rve"""
+
+    xmin_normal = np.array([-1.0, 0.0, 0.0])
+    ymin_normal = np.array([0.0, -1.0, 0.0])
+    zmin_normal = np.array([0.0, 0.0, -1.0])
+    xmax_normal = -xmin_normal
+    ymax_normal = -ymin_normal
+    zmax_normal = -zmin_normal
+
+    # there must be a better way:
+
+    bool_xmin = (
+        m.isclose(triangle.node1[0], rve.x_min)
+        and m.isclose(triangle.node2[0], rve.x_min)
+        and m.isclose(triangle.node3[0], rve.x_min)
+        and np.allclose(_compute_normal(triangle), xmin_normal)
+    )
+
+    bool_xmax = (
+        m.isclose(triangle.node1[0], rve.x_max)
+        and m.isclose(triangle.node2[0], rve.x_max)
+        and m.isclose(triangle.node3[0], rve.x_max)
+        and np.allclose(_compute_normal(triangle), xmax_normal)
+    )
+
+    bool_ymin = (
+        m.isclose(triangle.node1[1], rve.y_min)
+        and m.isclose(triangle.node2[1], rve.y_min)
+        and m.isclose(triangle.node3[1], rve.y_min)
+        and np.allclose(_compute_normal(triangle), ymin_normal)
+    )
+
+    bool_ymax = (
+        m.isclose(triangle.node1[1], rve.y_max)
+        and m.isclose(triangle.node2[1], rve.y_max)
+        and m.isclose(triangle.node3[1], rve.y_max)
+        and np.allclose(_compute_normal(triangle), ymax_normal)
+    )
+
+    bool_zmin = (
+        m.isclose(triangle.node1[2], rve.z_min)
+        and m.isclose(triangle.node2[2], rve.z_min)
+        and m.isclose(triangle.node3[2], rve.z_min)
+        and np.allclose(_compute_normal(triangle), zmin_normal)
+    )
+
+    bool_zmax = (
+        m.isclose(triangle.node1[2], rve.z_max)
+        and m.isclose(triangle.node2[2], rve.z_max)
+        and m.isclose(triangle.node3[2], rve.z_max)
+        and np.allclose(_compute_normal(triangle), zmax_normal)
+    )
+
+    return bool_xmin or bool_xmax or bool_ymin or bool_ymax or bool_zmin or bool_zmax
+
+
+def _extract_boundary_triangles_tags(
+    surface_triangles: list[Triangle], rve: Rve
+) -> list[int]:
+    n_tetrahedra = len(gmsh.model.mesh.getElements(_MESH_DIM)[1][0])
+    boundary_triangles_tags = [
+        int(triangle.tag - n_tetrahedra) # TODO add explicit comment
+        for triangle in surface_triangles
+        if _is_triangle_on_boundary(triangle, rve)
+    ]
+
+    return boundary_triangles_tags

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -25,19 +25,20 @@ def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
     :param output_mesh_file: output file (must be .mesh)
     """
     with NamedTemporaryFile(suffix='.mesh') as boundary_triangles_file:
-        identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
+        _identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
         Mmg.mmg3d(input=boundary_triangles_file.name, output=output_mesh_file, hausd=hausd, hgrad=hgrad, hmax=hmax,
                   hmin=hmin, hsiz=hsiz)
 
 
-def identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,
-                                               output_mesh_file: str) -> None:
+def _identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,
+                                                output_mesh_file: str) -> None:
     """
     Prepares the mesh file for periodic remeshing by tagging boundary triangles
 
     This function adds a "RequiredTriangles" field
     in the ".mesh" file that stores the boundary triangles tags.
     mmg recognizes this field as triangles it must not remesh
+
     :param input_mesh_file: mesh file to remesh (must be .mesh)
     :param rve: Representative Volume Element for periodicity
     :param output_mesh_file: output file (must be .mesh)

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -9,24 +9,29 @@ Triangle = namedtuple("Triangle", ["node1", "node2", "node3", "tag"])
 _MESH_DIM = 3
 _BOUNDARY_DIM = 2
 
+def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
+                                           output_mesh_file: str) -> None:
+    ...
 
-def remesh_periodic(
-        mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
-) -> None:
+def identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,
+                                               output_mesh_file: str) -> None:
     """
-    Prepares the mesh file for periodic remeshing
+    Prepares the mesh file for periodic remeshing by tagging boundary triangles
 
-    :param mesh_file: mesh file to remesh
-    :param rve: RVE for periodicity
-    :param output_file: output file (must be .mesh)
+    This function adds a "RequiredTriangles" field
+    in the ".mesh" file that stores the boundary triangles tags.
+    mmg recognizes this field as triangles it must not remesh
+    :param input_mesh_file: mesh file to remesh (must be .mesh)
+    :param rve: Representative Volume Element for periodicity
+    :param output_mesh_file: output file (must be .mesh)
     """
     gmsh.initialize()
-    gmsh.open(mesh_file)
+    gmsh.open(input_mesh_file)
 
-    surface_triangles = _build_surface_triangles()
-    boundary_triangles_tags = _extract_boundary_triangles_tags(surface_triangles, rve)
+    surface_triangles: list[Triangle] = _build_surface_triangles()
+    boundary_triangles_tags: list[int] = _extract_boundary_triangles_tags(surface_triangles, rve)
 
-    _write_output(boundary_triangles_tags, output_file)
+    _write_output(boundary_triangles_tags, output_mesh_file)
 
 
 def _get_surface_triangles() -> tuple[list[int], list[int]]:
@@ -154,7 +159,7 @@ def _write_output(boundary_triangles_tags: list[int], output_file: str = "mesh_r
     gmsh.finalize()
 
     with open(output_file, "r") as file:
-        lines = file.readlines()[:-1] # Delete last line End
+        lines = file.readlines()[:-1]  # Delete last line End
 
     with open(output_file, "w") as outfile:
         outfile.writelines(lines)

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -11,7 +11,7 @@ _BOUNDARY_DIM = 2
 
 
 def remesh_periodic(
-    mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
+        mesh_file: str, rve: Rve, output_file: str = "mesh_reqtri.mesh"
 ) -> None:
     """
     Prepares the mesh file for periodic remeshing
@@ -25,28 +25,12 @@ def remesh_periodic(
 
     gmsh.model.mesh.createTopology()  # Creates boundary entities
 
-    # Encapsulate this block into a private function
-    (
-        _,
-        surface_triangles_tags,
-        surface_triangles_nodes_tags,
-    ) = gmsh.model.mesh.getElements(_BOUNDARY_DIM)
-    surface_triangles_nodes_tags: list[int] = list(surface_triangles_nodes_tags[0])
-    surface_triangles_tags: list[int] = list(surface_triangles_tags[0])
-    #####
-
-    surface_triangles_nodes_coords = _get_surface_nodes_coords(
-        surface_triangles_nodes_tags
-    )
-
-    surface_triangles = _build_surface_triangles(
-        surface_triangles_tags, surface_triangles_nodes_coords
-    )
+    surface_triangles = _build_surface_triangles()
     boundary_triangles_tags = _extract_boundary_triangles_tags(surface_triangles, rve)
 
     n_boundary_triangles = len(boundary_triangles_tags)
 
-    # write files (there must be a more efficient way)
+    # write files (there must be a more efficient way) -> also encapsulate in a function
 
     gmsh.write(mesh_file[:-5] + "_triangles.mesh")
     gmsh.finalize()
@@ -63,9 +47,12 @@ def remesh_periodic(
         outfile.write("End\n")
 
 
-def _build_surface_triangles(
-    surface_triangles_tags: list[int], surface_triangles_nodes_coords: np.ndarray
-) -> list[Triangle]:
+def _build_surface_triangles() -> list[Triangle]:
+
+    surface_triangles_tags, surface_triangles_nodes_tags = _get_surface_triangles()
+    surface_triangles_nodes_coords = _get_surface_nodes_coords(
+        surface_triangles_nodes_tags)
+
     n_triangles = len(surface_triangles_tags)
     surface_triangles = [
         Triangle(
@@ -79,13 +66,16 @@ def _build_surface_triangles(
     return surface_triangles
 
 
-def _compute_normal(triangle: Triangle) -> np.ndarray:
-    """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
-    u = triangle.node2 - triangle.node1
-    v = triangle.node3 - triangle.node1
-    n = np.cross(u, v)
-    normal = n / np.linalg.norm(n)
-    return normal
+def _get_surface_triangles() -> tuple[list[int], list[int]]:
+    (
+        _,
+        surface_triangles_tags,
+        surface_triangles_nodes_tags,
+    ) = gmsh.model.mesh.getElements(_BOUNDARY_DIM)
+    surface_triangles_nodes_tags: list[int] = list(surface_triangles_nodes_tags[0])
+    surface_triangles_tags: list[int] = list(surface_triangles_tags[0])
+
+    return surface_triangles_tags, surface_triangles_nodes_tags
 
 
 def _get_surface_nodes_coords(surface_nodes: list[int]) -> np.ndarray:
@@ -94,6 +84,15 @@ def _get_surface_nodes_coords(surface_nodes: list[int]) -> np.ndarray:
     for i in range(n_nodes):
         surface_nodes_coords[i] = gmsh.model.mesh.getNode(surface_nodes[i])[0]
     return surface_nodes_coords
+
+
+def _compute_normal(triangle: Triangle) -> np.ndarray:
+    """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
+    u = triangle.node2 - triangle.node1
+    v = triangle.node3 - triangle.node1
+    n = np.cross(u, v)
+    normal = n / np.linalg.norm(n)
+    return normal
 
 
 def _is_triangle_on_boundary(triangle: Triangle, rve: Rve) -> bool:
@@ -109,56 +108,56 @@ def _is_triangle_on_boundary(triangle: Triangle, rve: Rve) -> bool:
     # there must be a better way:
 
     bool_xmin = (
-        m.isclose(triangle.node1[0], rve.x_min)
-        and m.isclose(triangle.node2[0], rve.x_min)
-        and m.isclose(triangle.node3[0], rve.x_min)
-        and np.allclose(_compute_normal(triangle), xmin_normal)
+            m.isclose(triangle.node1[0], rve.x_min)
+            and m.isclose(triangle.node2[0], rve.x_min)
+            and m.isclose(triangle.node3[0], rve.x_min)
+            and np.allclose(_compute_normal(triangle), xmin_normal)
     )
 
     bool_xmax = (
-        m.isclose(triangle.node1[0], rve.x_max)
-        and m.isclose(triangle.node2[0], rve.x_max)
-        and m.isclose(triangle.node3[0], rve.x_max)
-        and np.allclose(_compute_normal(triangle), xmax_normal)
+            m.isclose(triangle.node1[0], rve.x_max)
+            and m.isclose(triangle.node2[0], rve.x_max)
+            and m.isclose(triangle.node3[0], rve.x_max)
+            and np.allclose(_compute_normal(triangle), xmax_normal)
     )
 
     bool_ymin = (
-        m.isclose(triangle.node1[1], rve.y_min)
-        and m.isclose(triangle.node2[1], rve.y_min)
-        and m.isclose(triangle.node3[1], rve.y_min)
-        and np.allclose(_compute_normal(triangle), ymin_normal)
+            m.isclose(triangle.node1[1], rve.y_min)
+            and m.isclose(triangle.node2[1], rve.y_min)
+            and m.isclose(triangle.node3[1], rve.y_min)
+            and np.allclose(_compute_normal(triangle), ymin_normal)
     )
 
     bool_ymax = (
-        m.isclose(triangle.node1[1], rve.y_max)
-        and m.isclose(triangle.node2[1], rve.y_max)
-        and m.isclose(triangle.node3[1], rve.y_max)
-        and np.allclose(_compute_normal(triangle), ymax_normal)
+            m.isclose(triangle.node1[1], rve.y_max)
+            and m.isclose(triangle.node2[1], rve.y_max)
+            and m.isclose(triangle.node3[1], rve.y_max)
+            and np.allclose(_compute_normal(triangle), ymax_normal)
     )
 
     bool_zmin = (
-        m.isclose(triangle.node1[2], rve.z_min)
-        and m.isclose(triangle.node2[2], rve.z_min)
-        and m.isclose(triangle.node3[2], rve.z_min)
-        and np.allclose(_compute_normal(triangle), zmin_normal)
+            m.isclose(triangle.node1[2], rve.z_min)
+            and m.isclose(triangle.node2[2], rve.z_min)
+            and m.isclose(triangle.node3[2], rve.z_min)
+            and np.allclose(_compute_normal(triangle), zmin_normal)
     )
 
     bool_zmax = (
-        m.isclose(triangle.node1[2], rve.z_max)
-        and m.isclose(triangle.node2[2], rve.z_max)
-        and m.isclose(triangle.node3[2], rve.z_max)
-        and np.allclose(_compute_normal(triangle), zmax_normal)
+            m.isclose(triangle.node1[2], rve.z_max)
+            and m.isclose(triangle.node2[2], rve.z_max)
+            and m.isclose(triangle.node3[2], rve.z_max)
+            and np.allclose(_compute_normal(triangle), zmax_normal)
     )
 
     return bool_xmin or bool_xmax or bool_ymin or bool_ymax or bool_zmin or bool_zmax
 
 
 def _extract_boundary_triangles_tags(
-    surface_triangles: list[Triangle], rve: Rve
+        surface_triangles: list[Triangle], rve: Rve
 ) -> list[int]:
     n_tetrahedra = len(gmsh.model.mesh.getElements(_MESH_DIM)[1][0])
     boundary_triangles_tags = [
-        int(triangle.tag - n_tetrahedra) # TODO add explicit comment
+        int(triangle.tag - n_tetrahedra)  # TODO add explicit comment
         for triangle in surface_triangles
         if _is_triangle_on_boundary(triangle, rve)
     ]

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -3,6 +3,7 @@ from microgen import Rve, Mmg
 import numpy as np
 import math as m
 from tempfile import NamedTemporaryFile
+import os
 
 from typing import NamedTuple
 import numpy.typing as npt
@@ -38,10 +39,11 @@ def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
     :param hmin: Minimal edge size
     :param hsiz: Build a constant size map of size hsiz
     """
-    with NamedTemporaryFile(suffix='.mesh') as boundary_triangles_file:
+    with NamedTemporaryFile(suffix='.mesh', delete=False) as boundary_triangles_file:
         _identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
         Mmg.mmg3d(input=boundary_triangles_file.name, output=output_mesh_file, hausd=hausd, hgrad=hgrad, hmax=hmax,
                   hmin=hmin, hsiz=hsiz)
+    os.remove(boundary_triangles_file.name)  # to solve compatibility issues of NamedTemporaryFiles with Windows
 
 
 def _identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -91,24 +91,8 @@ def _get_surface_nodes_coords(surface_nodes: list[int]) -> np.ndarray:
     return surface_nodes_coords
 
 
-def _compute_normal(triangle: Triangle) -> np.ndarray:
-    """Computes normal vector of a triangle in mesh, defined by the coordinates of its three vertices"""
-    u = triangle.node2 - triangle.node1
-    v = triangle.node3 - triangle.node1
-    n = np.cross(u, v)
-    normal = n / np.linalg.norm(n)
-    return normal
-
-
 def _is_triangle_on_boundary(triangle: Triangle, rve: Rve) -> bool:
     """Determines whether a triangle (defined by its 3 nodes) is on the boundary of a parallelepipedic rve"""
-
-    xmin_normal = np.array([-1.0, 0.0, 0.0])
-    ymin_normal = np.array([0.0, -1.0, 0.0])
-    zmin_normal = np.array([0.0, 0.0, -1.0])
-    xmax_normal = -xmin_normal
-    ymax_normal = -ymin_normal
-    zmax_normal = -zmin_normal
 
     # there must be a better way:
 
@@ -116,42 +100,36 @@ def _is_triangle_on_boundary(triangle: Triangle, rve: Rve) -> bool:
             m.isclose(triangle.node1[0], rve.x_min)
             and m.isclose(triangle.node2[0], rve.x_min)
             and m.isclose(triangle.node3[0], rve.x_min)
-            and np.allclose(_compute_normal(triangle), xmin_normal)
     )
 
     bool_xmax = (
             m.isclose(triangle.node1[0], rve.x_max)
             and m.isclose(triangle.node2[0], rve.x_max)
             and m.isclose(triangle.node3[0], rve.x_max)
-            and np.allclose(_compute_normal(triangle), xmax_normal)
     )
 
     bool_ymin = (
             m.isclose(triangle.node1[1], rve.y_min)
             and m.isclose(triangle.node2[1], rve.y_min)
             and m.isclose(triangle.node3[1], rve.y_min)
-            and np.allclose(_compute_normal(triangle), ymin_normal)
     )
 
     bool_ymax = (
             m.isclose(triangle.node1[1], rve.y_max)
             and m.isclose(triangle.node2[1], rve.y_max)
             and m.isclose(triangle.node3[1], rve.y_max)
-            and np.allclose(_compute_normal(triangle), ymax_normal)
     )
 
     bool_zmin = (
             m.isclose(triangle.node1[2], rve.z_min)
             and m.isclose(triangle.node2[2], rve.z_min)
             and m.isclose(triangle.node3[2], rve.z_min)
-            and np.allclose(_compute_normal(triangle), zmin_normal)
     )
 
     bool_zmax = (
             m.isclose(triangle.node1[2], rve.z_max)
             and m.isclose(triangle.node2[2], rve.z_max)
             and m.isclose(triangle.node3[2], rve.z_max)
-            and np.allclose(_compute_normal(triangle), zmax_normal)
     )
 
     return bool_xmin or bool_xmax or bool_ymin or bool_ymax or bool_zmin or bool_zmax

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -1,17 +1,35 @@
 import gmsh
-from microgen import Rve
+from microgen import Rve, Mmg
 import numpy as np
 import math as m
 from collections import namedtuple
+from tempfile import NamedTemporaryFile
 
 Triangle = namedtuple("Triangle", ["node1", "node2", "node3", "tag"])
 
 _MESH_DIM = 3
 _BOUNDARY_DIM = 2
 
+
 def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
-                                           output_mesh_file: str) -> None:
-    ...
+                               output_mesh_file: str, hausd=None,
+                               hgrad=None,
+                               hmax=None,
+                               hmin=None,
+                               hsiz=None) -> None:
+    """
+    Remeshes a mesh (.mesh file format) using mmg while keeping periodicity
+
+    :param input_mesh_file: mesh file to remesh (must be .mesh)
+    :param rve: Representative Volume Element for periodicity
+    :param output_mesh_file: output file (must be .mesh)
+    """
+    boundary_triangles_file = NamedTemporaryFile(suffix='.mesh')
+    identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
+    Mmg.mmg3d(input=boundary_triangles_file.name, output=output_mesh_file, hausd=hausd, hgrad=hgrad, hmax=hmax,
+              hmin=hmin, hsiz=hsiz)
+    boundary_triangles_file.close()
+
 
 def identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,
                                                output_mesh_file: str) -> None:

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -26,7 +26,7 @@ def remesh_periodic(
     surface_triangles = _build_surface_triangles()
     boundary_triangles_tags = _extract_boundary_triangles_tags(surface_triangles, rve)
 
-    _write_output(boundary_triangles_tags, mesh_file, output_file)
+    _write_output(boundary_triangles_tags, output_file)
 
 
 def _get_surface_triangles() -> tuple[list[int], list[int]]:
@@ -148,16 +148,16 @@ def _extract_boundary_triangles_tags(
     return boundary_triangles_tags
 
 
-def _write_output(boundary_triangles_tags: list[int], mesh_file: str, output_file: str = "mesh_reqtri.mesh") -> None:
+def _write_output(boundary_triangles_tags: list[int], output_file: str = "mesh_reqtri.mesh") -> None:
     n_boundary_triangles = len(boundary_triangles_tags)
-    gmsh.write(mesh_file[:-5] + "_triangles.mesh")
+    gmsh.write(output_file)
     gmsh.finalize()
 
-    with open(mesh_file[:-5] + "_triangles.mesh", "r") as file:
-        lines = file.readlines()
+    with open(output_file, "r") as file:
+        lines = file.readlines()[:-1] # Delete last line End
 
-    with open(output_file, "w+") as outfile:
-        outfile.writelines(lines[:-1])
+    with open(output_file, "w") as outfile:
+        outfile.writelines(lines)
         outfile.write("RequiredTriangles\n")
         outfile.write(str(n_boundary_triangles) + "\n")
         for tag in boundary_triangles_tags:

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -24,11 +24,10 @@ def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
     :param rve: Representative Volume Element for periodicity
     :param output_mesh_file: output file (must be .mesh)
     """
-    boundary_triangles_file = NamedTemporaryFile(suffix='.mesh')
-    identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
-    Mmg.mmg3d(input=boundary_triangles_file.name, output=output_mesh_file, hausd=hausd, hgrad=hgrad, hmax=hmax,
-              hmin=hmin, hsiz=hsiz)
-    boundary_triangles_file.close()
+    with NamedTemporaryFile(suffix='.mesh') as boundary_triangles_file:
+        identify_boundary_triangles_from_mesh_file(input_mesh_file, rve, boundary_triangles_file.name)
+        Mmg.mmg3d(input=boundary_triangles_file.name, output=output_mesh_file, hausd=hausd, hgrad=hgrad, hmax=hmax,
+                  hmin=hmin, hsiz=hsiz)
 
 
 def identify_boundary_triangles_from_mesh_file(input_mesh_file: str, rve: Rve,

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -19,12 +19,12 @@ _MESH_DIM = 3
 _BOUNDARY_DIM = 2
 
 
-def remesh_keeping_periodicity(input_mesh_file: str, rve: Rve,
-                               output_mesh_file: str, hausd: float = None,
-                               hgrad: float = None,
-                               hmax: float = None,
-                               hmin: float = None,
-                               hsiz: float = None) -> None:
+def remesh_keeping_periodicity_for_fem(input_mesh_file: str, rve: Rve,
+                                       output_mesh_file: str, hausd: float = None,
+                                       hgrad: float = None,
+                                       hmax: float = None,
+                                       hmin: float = None,
+                                       hsiz: float = None) -> None:
     """
     Remeshes a mesh (.mesh file format) using mmg while keeping periodicity
 
@@ -99,7 +99,7 @@ def _build_surface_triangles() -> list[Triangle]:
     return surface_triangles
 
 
-def _get_surface_nodes_coords(surface_nodes: list[int]) -> np.ndarray:
+def _get_surface_nodes_coords(surface_nodes: list[int]) -> npt.NDArray[np.float_]:
     n_nodes = len(surface_nodes)
     surface_nodes_coords = np.zeros((n_nodes, _MESH_DIM))
     for i in range(n_nodes):

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -4,13 +4,14 @@ import microgen
 from microgen import Box, meshPeriodic, Phase, Rve, remesh, Tpms, tpms
 import cadquery as cq
 import numpy as np
+import numpy.typing as npt
 import gmsh
 from pathlib import Path
 
 MESH_DIM = 3
 
 
-def get_mesh_nodes_coords(mesh_name: str):
+def _get_mesh_nodes_coords(mesh_name: str) -> npt.NDArray[np.float64]:
     gmsh.initialize()
     gmsh.open(mesh_name)
 
@@ -22,7 +23,7 @@ def get_mesh_nodes_coords(mesh_name: str):
     return nodes_coords
 
 
-def is_periodic(nodes_coords, tol=1e-8, dim=MESH_DIM):
+def _is_periodic(nodes_coords, tol=1e-8, dim=MESH_DIM) -> bool:
     # bounding box
     xmax = np.max(nodes_coords[:, 0])
     xmin = np.min(nodes_coords[:, 0])
@@ -152,8 +153,8 @@ def tmp_output_mesh_filename(tmp_dir: Path) -> str:
     ],
 )
 def test_given_periodic_mesh_remesh_keeping_periodicity_must_maintain_periodicity(
-    shape,
-    mesh_element_size,
+    shape : microgen.BasicGeometry,
+    mesh_element_size : float,
     tmp_step_filename: str,
     tmp_mesh_filename: str,
     tmp_output_mesh_filename: str,
@@ -181,4 +182,4 @@ def test_given_periodic_mesh_remesh_keeping_periodicity_must_maintain_periodicit
     )
 
     # Assert
-    assert is_periodic(get_mesh_nodes_coords(tmp_output_mesh_filename))
+    assert _is_periodic(_get_mesh_nodes_coords(tmp_output_mesh_filename))

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,7 +1,5 @@
 import pytest
-
-import microgen
-from microgen import Box, meshPeriodic, Phase, Rve, remesh, Tpms, tpms
+from microgen import Box, meshPeriodic, Phase, Rve, remesh, Tpms, tpms, BasicGeometry
 import cadquery as cq
 import numpy as np
 import numpy.typing as npt
@@ -11,7 +9,7 @@ from pathlib import Path
 MESH_DIM = 3
 
 
-def _get_mesh_nodes_coords(mesh_name: str) -> npt.NDArray[np.float64]:
+def _get_mesh_nodes_coords(mesh_name: str) -> npt.NDArray[np.float_]:
     gmsh.initialize()
     gmsh.open(mesh_name)
 
@@ -153,7 +151,7 @@ def tmp_output_mesh_filename(tmp_dir: Path) -> str:
     ],
 )
 def test_given_periodic_mesh_remesh_keeping_periodicity_must_maintain_periodicity(
-    shape : microgen.BasicGeometry,
+    shape : BasicGeometry,
     mesh_element_size : float,
     tmp_step_filename: str,
     tmp_mesh_filename: str,

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,0 +1,120 @@
+from microgen import Box, meshPeriodic, Phase, Rve, remesh
+import cadquery as cq
+import numpy as np
+import gmsh
+
+MESH_DIM = 3
+
+def get_mesh_nodes_coords(mesh_name: str):
+
+    gmsh.initialize()
+    gmsh.open(mesh_name)
+
+    _, nodes_coords, _ = gmsh.model.mesh.getNodes()
+    nodes_coords = nodes_coords.reshape(-1, MESH_DIM)
+
+    return nodes_coords
+
+def is_periodic(nodes_coords, tol=1e-8, dim=MESH_DIM):
+    """
+        Test if a list of node coordinates is periodic (have nodes at the same positions on adjacent faces)
+
+        Parameters
+        ----------
+        nodes_coords: numpy array with shape = [n_nodes, ndim]
+            list of node coordinates associated to a mesh
+        tol : float (default = 1e-8)
+            Tolerance used to test the nodes positions.
+        dim : 1,2 or 3 (default = 3)
+            Dimension of the periodicity. If dim = 1, the periodicity is tested only over the 1st axis (x axis).
+            if dim = 2, the periodicity is tested on the 2 first axis (x and y axis).
+            if dim = 3, the periodicity is tested in 3 directions (x,y,z).
+
+        Returns
+        -------
+        True if the mesh is periodic else return False.
+        """
+
+    # bounding box
+    xmax = np.max(nodes_coords[:, 0])
+    xmin = np.min(nodes_coords[:, 0])
+    ymax = np.max(nodes_coords[:, 1])
+    ymin = np.min(nodes_coords[:, 1])
+    if dim == 3:
+        zmax = np.max(nodes_coords[:, 2])
+        zmin = np.min(nodes_coords[:, 2])
+
+    # extract face nodes
+    left = np.where(np.abs(nodes_coords[:, 0] - xmin) < tol)[0]
+    right = np.where(np.abs(nodes_coords[:, 0] - xmax) < tol)[0]
+
+    if dim > 1:
+        bottom = np.where(np.abs(nodes_coords[:, 1] - ymin) < tol)[0]
+        top = np.where(np.abs(nodes_coords[:, 1] - ymax) < tol)[0]
+
+    if dim > 2:  # or dim == 3
+        back = np.where(np.abs(nodes_coords[:, 2] - zmin) < tol)[0]
+        front = np.where(np.abs(nodes_coords[:, 2] - zmax) < tol)[0]
+
+        # sort adjacent faces to ensure node correspondance
+    if nodes_coords.shape[1] == 2:  # 2D mesh
+        left = left[np.argsort(nodes_coords[left, 1])]
+        right = right[np.argsort(nodes_coords[right, 1])]
+        if dim > 1:
+            bottom = bottom[np.argsort(nodes_coords[bottom, 0])]
+            top = top[np.argsort(nodes_coords[top, 0])]
+
+    elif nodes_coords.shape[1] > 2:
+        decimal_round = int(-np.log10(tol) - 1)
+        left = left[np.lexsort((nodes_coords[left, 1], nodes_coords[left, 2].round(decimal_round)))]
+        right = right[np.lexsort((nodes_coords[right, 1], nodes_coords[right, 2].round(decimal_round)))]
+        if dim > 1:
+            bottom = bottom[np.lexsort((nodes_coords[bottom, 0], nodes_coords[bottom, 2].round(decimal_round)))]
+            top = top[np.lexsort((nodes_coords[top, 0], nodes_coords[top, 2].round(decimal_round)))]
+        if dim > 2:
+            back = back[np.lexsort((nodes_coords[back, 0], nodes_coords[back, 1].round(decimal_round)))]
+            front = front[np.lexsort((nodes_coords[front, 0], nodes_coords[front, 1].round(decimal_round)))]
+
+    # ==========================
+    # test if mesh is periodic:
+    # ==========================
+
+    # test if same number of nodes in adjacent faces
+    if len(left) != len(right):
+        return False
+    if dim > 1 and len(bottom) != len(top):
+        return False
+    if dim > 2 and (len(back) != len(front)):
+        return False
+
+    # check nodes position
+    if (nodes_coords[right, 1:] - nodes_coords[left, 1:] > tol).any():
+        return False
+    if dim > 1 and (nodes_coords[top, ::2] - nodes_coords[bottom, ::2] > tol).any():
+        return False
+    if dim > 2 and (nodes_coords[front, :2] - nodes_coords[back, :2] > tol).any():
+        return False
+
+    return True
+
+def test_given_periodic_mesh_box_remesh_keeping_periodicity_must_maintain_periodicity():
+    # Arrange
+    rve = Rve()
+
+    geometry = Box()
+
+    shape = geometry.generate()
+    phase = Phase(shape)
+    # TODO replace this using tmp dir
+    cq.exporters.export(shape, 'box.step')
+
+    mesh_name = 'box_per.mesh'
+    output_mesh_name = 'box_per.o.mesh'
+
+    meshPeriodic('box.step', rve, [phase], size=1, order=1, output_file=mesh_name, mshFileVersion=4)
+
+    # Act
+    remesh.remesh_keeping_periodicity(mesh_name, rve, output_mesh_name, hgrad=1.1)
+
+    # Assert
+    assert is_periodic(get_mesh_nodes_coords(output_mesh_name))

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -167,11 +167,11 @@ def test_given_rve_and_internal_triangle_is_triangle_on_boundary_must_return_fal
     # Arrange
 
     rve = Rve(dim_x=1, dim_y=1, dim_z=1, center=(0, 0, 0))
-    triangle = remesh.Triangle(np.array([0.2, -0.25, -0.25]), np.array([0.2, 0.25, -0.25]),
+    internal_triangle = remesh.Triangle(np.array([0.2, -0.25, -0.25]), np.array([0.2, 0.25, -0.25]),
                                np.array([0.2, -0.25, 0.25]), 1)
 
     # Act & Assert
-    assert not remesh._is_triangle_on_boundary(triangle, rve)
+    assert not remesh._is_triangle_on_boundary(internal_triangle, rve)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Context

This pull request proposes a new feature for Microgen in `remesh.py`. In order to use periodic boundary conditions in Finite Element (FE) simulations, the mesh needs to be periodic. However, periodic meshes of some Microgen geometries, like TPMS, may be unsuitable for FE computations and need to be remeshed using mmg. However, mmg does not keep initial mesh periodicity without prior manipulations.

## Feature description

The function `remesh_keeping_periodicity()` reads the initial `.mesh` file as generated by Microgen using GMSH and identifies which triangles of said mesh are on the boundary of the RVE. These triangles are then marked as RequiredTriangles. This new RequiredTriangles field is added to the `.mesh` file, and is recognized by mmg as triangles it must keep intact when remeshing the whole mesh. The periodic output mesh is then generated by calling mmg.

## Testing

Tests are implemented in `test_remesh.py`. Output mesh periodicity is tested on a box (a shape without internal surfaces), and a gyroid (a shape with internal surfaces, i.e. which has surface triangles that do not belong to the boundary surface).

> :warning: Choosing to use files instead of a specific Mesh class to describe and store mesh data can lead to some unexpected behavior. Indeed, it is difficult to predict how GMSH and mmg tag different elements in the mesh when reading and writing `.mesh` files, which can result in some triangles not being marked as RequiredTriangles when they should be for relatively fine meshes. This new Mesh class will be implemented in a subsequent branch, and should avoid the aforementioned unwanted behavior.