### PR TITLE
Tpms density parameter

### DIFF
--- a/examples/TPMS/coordinate_system/cylindrical_graded.py
+++ b/examples/TPMS/coordinate_system/cylindrical_graded.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import numpy as np
 import pyvista as pv
 
@@ -8,22 +10,39 @@ from microgen.shape.surface_functions import gyroid
 def swapped_gyroid(x, y, z):
     return gyroid(x=z, y=y, z=x)
 
-def grading(x, y, z):
-    a = (max_offset - min_offset) / (np.max(x) - np.min(x))
-    b = max_offset - a * np.max(x)
 
-    return a * x + b
+def grading(
+    x: np.ndarray,
+    y: np.ndarray,
+    z: np.ndarray,
+    min_offset: float | np.ndarray = 0.0,
+    max_offset: float | np.ndarray = 3.0,
+) -> np.ndarray:
+    rad = np.sqrt(x**2 + y**2)
+    max_rad = np.max(rad)
+    min_rad = np.min(rad)
+
+    return min_offset + (max_offset - min_offset) * (rad - min_rad) / (
+        max_rad - min_rad
+    )
 
 
-min_offset = 0.
-max_offset = 3.
+full_density_offset = CylindricalTpms.offset_from_density(
+    surface_function=swapped_gyroid,
+    part_type="sheet",
+    density=1.0,
+)
 
 geometry = CylindricalTpms(
-    radius=10,
+    radius=5,
     surface_function=swapped_gyroid,
-    offset=grading,
+    offset=partial(
+        grading,
+        min_offset=0.0,
+        max_offset=full_density_offset,
+    ),
     cell_size=(1, 1, 1),
-    repeat_cell=(10, 0, 1),
+    repeat_cell=(5, 0, 1),
     resolution=20,
 )
 sheet = geometry.sheet

--- a/examples/TPMS/coordinate_system/spherical.py
+++ b/examples/TPMS/coordinate_system/spherical.py
@@ -7,6 +7,7 @@ from microgen.shape.surface_functions import gyroid
 def swapped_gyroid(x, y, z):
     return gyroid(x=z, y=y, z=x)
 
+
 geometry = SphericalTpms(
     surface_function=swapped_gyroid,
     offset=0.5,

--- a/examples/TPMS/gyroid/gyroid.py
+++ b/examples/TPMS/gyroid/gyroid.py
@@ -3,7 +3,7 @@ from microgen.shape.surface_functions import gyroid
 
 geometry = Tpms(
     surface_function=gyroid,
-    offset=0.3,
+    density=0.30,
     resolution=30,
 )
 shape = geometry.generateVtk(type_part="sheet").extract_surface()

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -111,16 +111,28 @@ class Tpms(BasicGeometry):
         density: float | Literal["max"] = "max",
         resolution: int = 20,
     ) -> float:
-        if not isinstance(density, float) or density != "max":
+        if not isinstance(density, (int, float)) and density != "max":
             raise ValueError("density must be a float between 0 and 1 or 'max'")
-        if density in ["max", 1.0]:
-            tpms = Tpms(
-                surface_function=surface_function,
-                resolution=resolution,
+        if density == "max":
+            if part_type == "sheet":
+                tpms = Tpms(surface_function=surface_function, resolution=resolution)
+                return 2.0 * np.max(tpms.grid["surface"])
+            return 0.0  # skeletal
+
+        if "skeletal" in part_type:
+            tpms = Tpms(surface_function=surface_function, resolution=resolution)
+            max_density = (
+                getattr(tpms, f"vtk_{part_type.replace(' ', '_')}")().volume
+                / tpms.grid.volume
             )
-            return 2.0 * np.max(tpms.grid["surface"]) if part_type == "sheet" else 0.0
-        if not 0.0 < density < 1.0:
-            raise ValueError("density must be a float between 0 and 1 or 'max'")
+        else:
+            max_density = 1.0
+
+        if not 0.0 < density <= max_density:
+            raise ValueError(
+                f"density must be between 0 and {max_density:.2%} for \
+                    the {part_type} part of the given TPMS function"
+            )
 
         tpms = Tpms(surface_function=surface_function, density=density)
         tpms._compute_offset_to_fit_density(part_type=part_type, resolution=resolution)
@@ -144,7 +156,8 @@ class Tpms(BasicGeometry):
             )
             if self.density > max_density:
                 raise ValueError(
-                    f"density must be lower than {max_density:.2%} for the {part_type} part of the given TPMS function"
+                    f"density must be lower than {max_density:.2%} for \
+                        the {part_type} part of the given TPMS function"
                 )
 
         if self.density == 1.0:

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -116,13 +116,13 @@ class Tpms(BasicGeometry):
             repeat_cell=self.repeat_cell,
             resolution=resolution if resolution < self.resolution else self.resolution,
         )
-        grid_volume = np.prod(self.cell_size) * np.prod(self.repeat_cell)
+        grid_volume = temp_tpms.grid.volume
 
         polydata_func = getattr(temp_tpms, f"vtk_{part_type.replace(' ', '_')}")
 
         def density(offset: float):
             temp_tpms._update_offset(offset)
-            return abs(polydata_func().volume) / grid_volume
+            return polydata_func().volume / grid_volume
 
         computed_offset = root_scalar(
             lambda offset: density(offset) - self.density,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "pyvista",
     "gmsh",
     "meshio",
-    "cadquery"
+    "cadquery",
+    "scipy",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -341,13 +341,6 @@ def test_tpms_given_wrong_density_parameter_must_raise_ValueError():
             density=1.0,
         )
 
-    with pytest.raises(ValueError):
-        tpms = microgen.Tpms(
-            surface_function=microgen.surface_functions.gyroid,
-            density=0.5,
-        )
-        tpms.generateVtk(type_part="lower skeletal")
-
 
 def test_tpms_given_property_must_return_the_same_value():
     tpms = microgen.Tpms(

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -335,6 +335,31 @@ def test_tpms_given_wrong_density_parameter_must_raise_ValueError():
             density=0.0,
         )
 
+    with pytest.raises(ValueError):
+        microgen.Tpms.offset_from_density(
+            surface_function=microgen.surface_functions.gyroid,
+            density="fake",
+            part_type="sheet",
+        )
+
+    with pytest.raises(ValueError):
+        microgen.Tpms.offset_from_density(
+            surface_function=microgen.surface_functions.gyroid,
+            density=1.0,
+            part_type="lower skeletal",
+        )
+
+
+@pytest.mark.parametrize("type_part", ["lower skeletal", "upper skeletal", "sheet"])
+def test_tpms_given_density_must_generate_tpms_with_correct_volume(type_part: str):
+    tpms = microgen.Tpms(
+        surface_function=microgen.surface_functions.gyroid,
+        density=0.2,
+    )
+
+    part = tpms.generateVtk(type_part=type_part)
+    assert np.isclose(part.volume, tpms.grid.volume * 0.2, rtol=1e-2)
+
 
 def test_tpms_given_property_must_return_the_same_value():
     tpms = microgen.Tpms(

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -361,6 +361,47 @@ def test_tpms_given_density_must_generate_tpms_with_correct_volume(type_part: st
     assert np.isclose(part.volume, tpms.grid.volume * 0.2, rtol=1e-2)
 
 
+@pytest.mark.parametrize("part_type", ["lower skeletal", "upper skeletal", "sheet"])
+def test_tpms_given_max_density_must_return_corresponding_offset(
+    part_type: Literal["sheet", "lower skeletal", "upper skeletal"]
+):
+    tpms = microgen.Tpms(
+        surface_function=microgen.surface_functions.gyroid,
+    )
+
+    max_offset = microgen.Tpms.offset_from_density(
+        surface_function=microgen.surface_functions.gyroid,
+        density="max",
+        part_type=part_type,
+    )
+    expected_max_offset = (
+        2.0 * np.max(tpms.grid["surface"]) if part_type == "sheet" else 0.0
+    )
+    assert max_offset == expected_max_offset
+
+
+def test_tpms_given_100_percent_sheet_density_must_return_a_cube():
+    tpms = microgen.Tpms(
+        surface_function=microgen.surface_functions.gyroid,
+        density=1.0,
+    )
+
+    assert np.isclose(tpms.sheet.volume, tpms.grid.volume, rtol=1.0e-9)
+
+
+def test_tpms_given_density_must_return_corresponding_offset():
+    tpms = microgen.Tpms(
+        surface_function=microgen.surface_functions.gyroid,
+    )
+
+    offset = microgen.Tpms.offset_from_density(
+        surface_function=microgen.surface_functions.gyroid,
+        density=0.5,
+        part_type="sheet",
+    )
+    assert 0 < offset < 2.0 * np.max(tpms.grid["surface"])
+
+
 def test_tpms_given_property_must_return_the_same_value():
     tpms = microgen.Tpms(
         surface_function=microgen.surface_functions.gyroid,

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -335,12 +335,6 @@ def test_tpms_given_wrong_density_parameter_must_raise_ValueError():
             density=0.0,
         )
 
-    with pytest.raises(ValueError):
-        microgen.Tpms(
-            surface_function=microgen.surface_functions.gyroid,
-            density=1.0,
-        )
-
 
 def test_tpms_given_property_must_return_the_same_value():
     tpms = microgen.Tpms(


### PR DESCRIPTION
# Overview

The offset parameter is a value that is specific to each surface function and it is often difficult to know what value to use.
This PR brings a density parameter to the Tpms class. The corresponding offset will be automatically computed to fit the required density (volumic fraction of solid). It uses a dichotomy algorithm. It could be improved but it works well already.

A refactoring of the `generate` method has also been done ans more tests have been added to reach a 99% coverage on the `tpms.py` file.

## Details
- Whether density or offset parameter is given, the density of the generated geometry will be printed
- If the density parameter is given (0 < density < 1), a dichotomy algorithm will compute the offset value that fits best with the required density.

## Edit
- Using `scipy.optimize.root_scalar` instead of the dichotomy algorithm, it is more precise, a bit faster and allow more possibilities including negative offsets for skeletal parts
- The algorithm uses a temporary Tpms object with the same parameters but low resolution to run faster especially when a high resolution Tpms is required