### PR TITLE
Update workflow to be able to create a conda package from another branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,9 @@
 name: Build and Test
 
 on:
-  push:
-    branches:
-      - "*"
+  # push:
+  #   branches:
+  #     - "*"
 
   # pull_request:
   #   branches:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,13 +1,9 @@
 name: Build and Test
 
 on:
-  # push:
-  #   branches:
-  #     - "*"
-
-  # pull_request:
-  #   branches:
-  #     - "*"
+  push:
+    branches:
+      - "*"
 
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-  push:
-    branches:
-      - "*"
 
 jobs:
   conda-packaging:

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -18,15 +18,17 @@ jobs:
           miniconda-version: "latest"
           activate-environment: packaging
       - name: Extract branch name
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
 
       - name: Use the branch name
-        run: echo "The branch name is $BRANCH_NAME"
-      - name: Conda build
-        shell: pwsh
-        run: |
-          conda install python conda-build conda-verify anaconda-client
-          anaconda logout
-          anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
-          conda-build conda.recipe -c conda-forge --output-folder  .
-          anaconda upload noarch/*.tar.bz2 --force
+        run: echo "The branch name is ${{ steps.extract_branch.outputs.branch }}
+      # - name: Conda build
+      #   shell: pwsh
+      #   run: |
+      #     conda install python conda-build conda-verify anaconda-client
+      #     anaconda logout
+      #     anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
+      #     conda-build conda.recipe -c conda-forge --output-folder  .
+      #     anaconda upload noarch/*.tar.bz2 --force

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -20,16 +20,22 @@ jobs:
           miniconda-version: "latest"
           activate-environment: packaging
       - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: extract_branch
-
-      - name: Use the branch name
+        if: ${{ github.event.issue.pull_request }}
         shell: pwsh
-        run: |
-          $env:BRANCH_NAME2="${{ steps.extract_branch.outputs.branch }}"
-          echo "branch name 2 is $env:BRANCH_NAME2"
-          echo "branch name is $env:BRANCH_NAME"
+        run: echo $env:PR_NUMBER
+        env:
+          PR_NUMBER: "PR_${{ github.event.issue.number }}"
+        # shell: bash
+        # run: |
+        #   echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        # id: extract_branch
+
+      # - name: Use the branch name
+      #   shell: pwsh
+      #   run: |
+      #     $env:BRANCH_NAME2="${{ steps.extract_branch.outputs.branch }}"
+      #     echo "branch name 2 is $env:BRANCH_NAME2"
+      #     echo "branch name is $env:BRANCH_NAME"
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "branch name $env:CONDA_BUILD_STRING"
         env:
-          CONDA_BUILD_STRING: "${{ github.head_ref || github.ref_name }}".replace("-","_")
+          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }}.replace("-","_")
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -1,16 +1,12 @@
 name: Create conda package
 
 on:
-  pull_request:
   workflow_dispatch:
-  push:
-    branches:
-      - "*"
 
 jobs:
   conda-packaging:
     name: Conda packaging
-    runs-on: "windows-latest"
+    runs-on: "ubuntu-latest"
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
@@ -26,16 +22,15 @@ jobs:
       #   run: echo $env:CONDA_BUILD_STRING
       #   env:
       #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
-
       - name: Conda build
         shell: pwsh
         run: |
-          $env:CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}" -replace "-","_"
-          echo "branch name $env:CONDA_BUILD_STRING"
+          CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}//-/_"
+          echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda logout
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .
           anaconda upload noarch/*.tar.bz2 --force
-        env:
-          CONDA_BUILD_STRING: ${{ env.CONDA_BUILD_STRING }}
+        # env:
+        #   CONDA_BUILD_STRING: ${{ env.CONDA_BUILD_STRING }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -15,10 +15,11 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          activate-environment: packaging
+      # - uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     miniconda-version: "latest"
+      #     activate-environment: packaging
+
       # - name: Extract PR number
       #   if: ${{ github.event.issue.pull_request }}
       #   shell: pwsh
@@ -29,14 +30,13 @@ jobs:
       - name: Extract branch name
         shell: pwsh
         run: |
+          $env:CONDA_BUILD_STRING = ${{ github.head_ref || github.ref_name }} -replace "-","_"
           echo "branch name $env:CONDA_BUILD_STRING"
-        env:
-          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }} -replace "-","_"
-      - name: Conda build
-        shell: pwsh
-        run: |
-          conda install python conda-build conda-verify anaconda-client
-          anaconda logout
-          anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
-          conda-build conda.recipe -c conda-forge --output-folder  .
-          anaconda upload noarch/*.tar.bz2 --force
+      # - name: Conda build
+      #   shell: pwsh
+      #   run: |
+      #     conda install python conda-build conda-verify anaconda-client
+      #     anaconda logout
+      #     anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
+      #     conda-build conda.recipe -c conda-forge --output-folder  .
+      #     anaconda upload noarch/*.tar.bz2 --force

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Extract branch name
         shell: pwsh
         run: |
-          $env:CONDA_BUILD_STRING = ${{ github.head_ref || github.ref_name }} -replace "-","_"
+          $env:CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}" -replace "-","_"
           echo "branch name $env:CONDA_BUILD_STRING"
       # - name: Conda build
       #   shell: pwsh

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -2,6 +2,8 @@ name: Create conda package
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   push:
     branches:
       - "*"
@@ -17,17 +19,11 @@ jobs:
           miniconda-version: "latest"
           activate-environment: packaging
 
-      # - name: Extract PR number
-      #   if: ${{ github.event.issue.pull_request }}
-      #   shell: pwsh
-      #   run: echo $env:CONDA_BUILD_STRING
-      #   env:
-      #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
       - name: Conda build
         shell: bash -l {0}
         run: |
-          export CONDA_BUILD_STRING="${BRANCH_NAME//-/_}"
-          echo "branch name $CONDA_BUILD_STRING"
+          export PACKAGE_VERSION="${BRANCH_NAME//-/_}"
+          echo "branch name $PACKAGE_VERSION"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,7 +26,7 @@ jobs:
       #   env:
       #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
       - name: Conda build
-        shell: pwsh
+        shell: bash
         run: |
           CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}//-/_"
           echo "branch name $CONDA_BUILD_STRING"

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -2,6 +2,9 @@ name: Create conda package
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "*"
 
 jobs:
   conda-packaging:

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Extract branch name
         shell: pwsh
         run: |
-          echo branch name $env:CONDA_BUILD_STRING
+          echo "branch name $env:CONDA_BUILD_STRING"
         env:
-          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }}.replace("-","_")
+          CONDA_BUILD_STRING: "${{ github.head_ref || github.ref_name }}".replace("-","_")
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Conda build
         shell: bash -l {0}
         run: |
+          export CONDA_BUILD_STRING="${BRANCH_NAME//-/_}"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
@@ -34,4 +35,3 @@ jobs:
           anaconda logout
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          CONDA_BUILD_STRING: "${BRANCH_NAME//-/_}"

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -23,7 +23,6 @@ jobs:
         shell: bash -l {0}
         run: |
           export PACKAGE_VERSION="${BRANCH_NAME//-/_}"
-          echo "branch name $PACKAGE_VERSION"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -27,14 +27,11 @@ jobs:
       #   env:
       #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
 
-      - name: Extract branch name
+      - name: Conda build
         shell: pwsh
         run: |
           $env:CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}" -replace "-","_"
           echo "branch name $env:CONDA_BUILD_STRING"
-      - name: Conda build
-        shell: pwsh
-        run: |
           conda install python conda-build conda-verify anaconda-client
           anaconda logout
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -11,6 +11,8 @@ jobs:
   conda-packaging:
     name: Conda packaging
     runs-on: "windows-latest"
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
@@ -25,7 +27,8 @@ jobs:
       - name: Use the branch name
         shell: pwsh
         run: |
-          BRANCH_NAME=${{ steps.extract_branch.outputs.branch }}
+          $env:BRANCH_NAME2=${{ steps.extract_branch.outputs.branch }}
+          echo "branch name 2 is $BRANCH_NAME2"
           echo "branch name is $BRANCH_NAME"
       - name: Conda build
         shell: pwsh

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -23,12 +23,15 @@ jobs:
         id: extract_branch
 
       - name: Use the branch name
-        run: echo "The branch name is ${{ steps.extract_branch.outputs.branch }}"
-      # - name: Conda build
-      #   shell: pwsh
-      #   run: |
-      #     conda install python conda-build conda-verify anaconda-client
-      #     anaconda logout
-      #     anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
-      #     conda-build conda.recipe -c conda-forge --output-folder  .
-      #     anaconda upload noarch/*.tar.bz2 --force
+        shell: pwsh
+        run: |
+          BRANCH_NAME=${{ steps.extract_branch.outputs.branch }}
+          echo "branch name is $BRANCH_NAME"
+      - name: Conda build
+        shell: pwsh
+        run: |
+          conda install python conda-build conda-verify anaconda-client
+          anaconda logout
+          anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
+          conda-build conda.recipe -c conda-forge --output-folder  .
+          anaconda upload noarch/*.tar.bz2 --force

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -23,7 +23,7 @@ jobs:
         id: extract_branch
 
       - name: Use the branch name
-        run: echo "The branch name is ${{ steps.extract_branch.outputs.branch }}
+        run: echo "The branch name is ${{ steps.extract_branch.outputs.branch }}"
       # - name: Conda build
       #   shell: pwsh
       #   run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "branch name $env:CONDA_BUILD_STRING"
         env:
-          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }}.replace("-","_")
+          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }} -replace "-","_"
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -1,7 +1,11 @@
 name: Create conda package
 
 on:
+  pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - "*"
 
 jobs:
   conda-packaging:

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           miniconda-version: "latest"
           activate-environment: packaging
+      - run: echo $GIT_DESCRIBE_TAG
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -40,3 +40,5 @@ jobs:
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .
           anaconda upload noarch/*.tar.bz2 --force
+        env:
+          CONDA_BUILD_STRING: ${{ env.CONDA_BUILD_STRING }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -10,8 +10,6 @@ jobs:
   conda-packaging:
     name: Conda packaging
     runs-on: "ubuntu-latest"
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
@@ -35,5 +33,5 @@ jobs:
           conda-build conda.recipe -c conda-forge --output-folder  .
           anaconda upload noarch/*.tar.bz2 --force
           anaconda logout
-        # env:
-        #   CONDA_BUILD_STRING: ${{ env.CONDA_BUILD_STRING }}
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   conda-packaging:
     name: Conda packaging
-    runs-on: "ubuntu-latest"
+    runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
@@ -20,9 +20,10 @@ jobs:
           activate-environment: packaging
 
       - name: Conda build
-        shell: bash -l {0}
+        shell: pwsh
         run: |
-          export PACKAGE_VERSION="${BRANCH_NAME//-/_}"
+          # export PACKAGE_VERSION="${BRANCH_NAME//-/_}"
+          $env:PACKAGE_VERSION = $env:BRANCH_NAME -replace "-", "_"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -28,8 +28,8 @@ jobs:
         shell: pwsh
         run: |
           $env:BRANCH_NAME2="${{ steps.extract_branch.outputs.branch }}"
-          echo "branch name 2 is $BRANCH_NAME2"
-          echo "branch name is $BRANCH_NAME"
+          echo "branch name 2 is $env:BRANCH_NAME2"
+          echo "branch name is $env:BRANCH_NAME"
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Conda build
         shell: bash
         run: |
-          CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}//-/_"
+          CONDA_BUILD_STRING="${{ github.head_ref || github.ref_name }}//-/_"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda logout

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -11,8 +11,6 @@ jobs:
   conda-packaging:
     name: Conda packaging
     runs-on: "windows-latest"
-    env:
-      BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
@@ -20,9 +18,7 @@ jobs:
           miniconda-version: "latest"
           activate-environment: packaging
       - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: extract_branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -19,23 +19,19 @@ jobs:
         with:
           miniconda-version: "latest"
           activate-environment: packaging
-      - name: Extract branch name
-        if: ${{ github.event.issue.pull_request }}
-        shell: pwsh
-        run: echo $env:PR_NUMBER
-        env:
-          PR_NUMBER: "PR_${{ github.event.issue.number }}"
-        # shell: bash
-        # run: |
-        #   echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        # id: extract_branch
-
-      # - name: Use the branch name
+      # - name: Extract PR number
+      #   if: ${{ github.event.issue.pull_request }}
       #   shell: pwsh
-      #   run: |
-      #     $env:BRANCH_NAME2="${{ steps.extract_branch.outputs.branch }}"
-      #     echo "branch name 2 is $env:BRANCH_NAME2"
-      #     echo "branch name is $env:BRANCH_NAME"
+      #   run: echo $env:CONDA_BUILD_STRING
+      #   env:
+      #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
+
+      - name: Extract branch name
+        shell: pwsh
+        run: |
+          echo branch name $env:CONDA_BUILD_STRING
+        env:
+          CONDA_BUILD_STRING: ${{ github.head_ref || github.ref_name }}.replace("-","_")
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Conda build
         shell: bash -l {0}
         run: |
-          CONDA_BUILD_STRING="${BRANCH_NAME//-/_}"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
@@ -35,3 +34,4 @@ jobs:
           anaconda logout
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          CONDA_BUILD_STRING: "${BRANCH_NAME//-/_}"

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -18,7 +18,10 @@ jobs:
           miniconda-version: "latest"
           activate-environment: packaging
       - name: Extract branch name
-        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Use the branch name
+        run: echo "The branch name is $BRANCH_NAME"
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,15 +26,14 @@ jobs:
       #   env:
       #     CONDA_BUILD_STRING: "PR_${{ github.event.issue.number }}"
       - name: Conda build
-        shell: bash
+        shell: bash -l {0}
         run: |
-          CONDA_BUILD_STRING=${{ github.head_ref || github.ref_name }}
-          CONDA_BUILD_STRING="${CONDA_BUILD_STRING//\//-}"
+          CONDA_BUILD_STRING="${BRANCH_NAME//\//-}"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
-          anaconda logout
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
           conda-build conda.recipe -c conda-forge --output-folder  .
           anaconda upload noarch/*.tar.bz2 --force
+          anaconda logout
         # env:
         #   CONDA_BUILD_STRING: ${{ env.CONDA_BUILD_STRING }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use the branch name
         shell: pwsh
         run: |
-          $env:BRANCH_NAME2=${{ steps.extract_branch.outputs.branch }}
+          $env:BRANCH_NAME2="${{ steps.extract_branch.outputs.branch }}"
           echo "branch name 2 is $BRANCH_NAME2"
           echo "branch name is $BRANCH_NAME"
       - name: Conda build

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -15,10 +15,10 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
-      # - uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     miniconda-version: "latest"
-      #     activate-environment: packaging
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          activate-environment: packaging
 
       # - name: Extract PR number
       #   if: ${{ github.event.issue.pull_request }}
@@ -32,11 +32,11 @@ jobs:
         run: |
           $env:CONDA_BUILD_STRING = "${{ github.head_ref || github.ref_name }}" -replace "-","_"
           echo "branch name $env:CONDA_BUILD_STRING"
-      # - name: Conda build
-      #   shell: pwsh
-      #   run: |
-      #     conda install python conda-build conda-verify anaconda-client
-      #     anaconda logout
-      #     anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
-      #     conda-build conda.recipe -c conda-forge --output-folder  .
-      #     anaconda upload noarch/*.tar.bz2 --force
+      - name: Conda build
+        shell: pwsh
+        run: |
+          conda install python conda-build conda-verify anaconda-client
+          anaconda logout
+          anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
+          conda-build conda.recipe -c conda-forge --output-folder  .
+          anaconda upload noarch/*.tar.bz2 --force

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Conda build
         shell: bash
         run: |
-          CONDA_BUILD_STRING="${{ github.head_ref || github.ref_name }}//-/_"
+          CONDA_BUILD_STRING=${{ github.head_ref || github.ref_name }}
+          CONDA_BUILD_STRING="${CONDA_BUILD_STRING//\//-}"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda logout

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -12,12 +12,11 @@ jobs:
     name: Conda packaging
     runs-on: "windows-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: packaging
-      - run: echo $GIT_DESCRIBE_TAG
       - name: Conda build
         shell: pwsh
         run: |

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Conda build
         shell: bash -l {0}
         run: |
-          CONDA_BUILD_STRING="${BRANCH_NAME//\//-}"
+          CONDA_BUILD_STRING="${BRANCH_NAME//-/_}"
           echo "branch name $CONDA_BUILD_STRING"
           conda install python conda-build conda-verify anaconda-client
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}

--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -11,17 +11,23 @@ jobs:
   conda-packaging:
     name: Conda packaging
     runs-on: "windows-latest"
+    env:
+      BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: packaging
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
       - name: Conda build
         shell: pwsh
         run: |
           conda install python conda-build conda-verify anaconda-client
           anaconda logout
           anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
-          conda-build conda.recipe -c conda-forge -c set3mah --output-folder  .
+          conda-build conda.recipe -c conda-forge --output-folder  .
           anaconda upload noarch/*.tar.bz2 --force

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  string: {{ environ.get('PR_NUMBER') }}
+  string: {{ environ.get('CONDA_BUILD_STRING') }}
 
 requirements:
   host:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,34 +1,50 @@
+{% set name = "microgen" %}
 {% set version = "1.0.1" %}
 
 package:
-  name: microgen
-  version: {{ version }}
+  name: {{ name|lower }}
+  version: {{ environ.get('PACKAGE_VERSION') }}
 
 source:
-  git_url: https://github.com/3MAH/microgen.git
+  path: ..
 
 build:
   noarch: python
-  script: pip install .
+  script: {{ PYTHON }} -m pip install . -vv
+  string: {{ GIT_DESCRIBE_TAG }}
 
 requirements:
   host:
-    - python
+    - python >=3.8
     - pip    
   run:
-    - pyvista>=0.39
+    - python >=3.8
+    - numpy
+    - pyvista
     - python-gmsh
     - meshio
     - cadquery
-    - pytest-cov
-#    - mmg
-#    - neper
+    - scipy
 
 test:
   imports:
     - microgen
-  source_files:
-    - tests
-    - examples
   commands:
-    - pytest tests
+    # - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/3MAH/microgen
+  summary: 'Microstructure generation'
+  description: |
+    Microstructure generation.
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  doc_url: https://microgen.readthedocs.io
+  dev_url: https://github.com/3MAH/microgen
+
+extra:
+  recipe-maintainers:
+    - kmarchais

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ environ.get('PACKAGE_VERSION') }}
 
 source:
-  path: ..
+  git_url: ../
 
 build:
   noarch: python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/3MAH/microgen.git
-  git_tag: {{ environ.get('PACKAGE_VERSION') }}
+  git_tag: {{ GIT_DESCRIBE_TAG }}
 
 build:
   noarch: python
@@ -35,7 +35,7 @@ about:
   home: https://github.com/3MAH/microgen
   summary: 'Microstructure generation'
   description: |
-    Microstructure generation.
+    Microgen is a Python library designed to facilitate microstructure generation and meshing.
   license: GPL-3.0-or-later
   license_family: GPL
   license_file: LICENSE

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  string: {{ GIT_DESCRIBE_TAG }}
+  string: {{ environ.get('GIT_DESCRIBE_TAG') }}
 
 requirements:
   host:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/3MAH/microgen.git
-  git_tag: {{ GIT_DESCRIBE_TAG }}
+  git_tag: {{ environ.get('BRANCH_NAME') }}
 
 build:
   noarch: python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,8 +1,6 @@
-{% set version = "1.0.1" %}
-
 package:
   name: microgen
-  version: {{ version }}
+  version: {{ environ.get('PACKAGE_VERSION') }}
 
 source:
   git_url: ../
@@ -10,7 +8,6 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  string: {{ environ.get('CONDA_BUILD_STRING') }}
 
 requirements:
   host:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: microgen
-  version: {{ environ.get('GIT_DESCRIBE_TAG') }}
+  version: {{ environ.get('BRANCH_NAME') }}
 
 source:
   git_url: ../

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: {{ environ.get('PACKAGE_VERSION') }}
 
 source:
-  git_url: ../
+  git_url: https://github.com/3MAH/microgen.git
+  git_tag: {{ environ.get('PACKAGE_VERSION') }}
 
 build:
   noarch: python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: microgen
-  version: {{ environ.get('BRANCH_NAME') }}
+  version: {{ version }}
 
 source:
   git_url: ../
@@ -10,6 +10,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  string: {{ environ.get('BRANCH_NAME') }}
 
 requirements:
   host:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  string: {{ environ.get('BRANCH_NAME') }}
+  string: {{ environ.get('PR_NUMBER') }}
 
 requirements:
   host:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,9 +1,8 @@
-{% set name = "microgen" %}
 {% set version = "1.0.1" %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ environ.get('PACKAGE_VERSION') }}
+  name: microgen
+  version: {{ environ.get('GIT_DESCRIBE_TAG') }}
 
 source:
   git_url: ../
@@ -11,7 +10,6 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  string: {{ environ.get('GIT_DESCRIBE_TAG') }}
 
 requirements:
   host:


### PR DESCRIPTION
# Overview
The goal of this PR is to make the creation of a conda package of a branch possible and also to trigger the conda package creation everytime there is a new release. 
- The package created from a branch would be named `microgen-branch_name` with the branch name replacing the version of the release. The created package can then be installed by running `conda install (c conda-forge -c set3mah microgen=branch_name`.
- A branch name containing "-" would use "_" instead since it is not possible to use the character "-" in the conda package version
- The conda recipe has been modified to use the environment variables to be able to do that

### Conda recipe and preparation for conda-forge channel:
- Other changes has been made to the conda recipe to make it closer to what is expected when submitting packages to the conda-forge channel
- In the test section, `pip check` because it says that gmsh and vtk are missing but I was not able to solve this problem. I guess it  is because gmsh and vtk are not the same packages between pip and conda.
- For the license, I am not sure if it must be `GPL-3.0-or-later` or `GPL-3.0-only`
- As `recipe-maintainers`, I put myself. Let me know if you agree to be in this list too. To be able to publish the package in the conda-forge channel later, it will be required to add a message in this [PR ](https://github.com/conda-forge/staged-recipes/pull/23864) to confirm it.