### PR TITLE
Bugfix mesh periodic

### DIFF
--- a/microgen/__init__.py
+++ b/microgen/__init__.py
@@ -8,5 +8,6 @@ from .phase import *
 from .rve import *
 from .shape import *
 from .report import *
+from .test_utils import *
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -154,7 +154,7 @@ def _iter_matching_bounding_boxes(rve: Rve, axis: int) -> Iterator[tuple[int, in
 
     # Get all the entities on the surface m (minimum value on axis, i.e. Xm, Ym or Zm)
     for bounds_min, tag_min in _iter_bounding_boxes(minimum, maximum, eps):
-        # Translate the minmal bounds into the maximum value on axis surface       
+        # Translate the minimal bounds into the maximum value on axis surface       
         bounds_min[:, axis] += 1
         # Get all the entities on the corresponding surface (i.e. Xp, Yp or Zp)        
         for bounds_max, tag_max in _iter_bounding_boxes(bounds_min[0], bounds_min[1], eps):

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -133,6 +133,7 @@ def _iter_bounding_boxes(minimum: _Point3D, maximum: _Point3D, eps: float) -> It
         *np.add(maximum, eps),
         dim=2
     )
+
     for dim, tag in entities:
         bounds = np.asarray(gmsh.model.getBoundingBox(
             dim, tag
@@ -143,19 +144,25 @@ def _iter_bounding_boxes(minimum: _Point3D, maximum: _Point3D, eps: float) -> It
 def _get_deltas(rve: Rve) -> np.ndarray:  # To add as a property of Rve?
     return np.array([rve.dx, rve.dy, rve.dz])
 
+def _get_min(rve: Rve) -> np.ndarray:  # To add as a property of Rve?
+    return np.array([rve.x_min, rve.y_min, rve.z_min])
+
+def _get_max(rve: Rve) -> np.ndarray:  # To add as a property of Rve?
+    return np.array([rve.x_max, rve.y_max, rve.z_max])
 
 def _iter_matching_bounding_boxes(rve: Rve, axis: int) -> Iterator[tuple[int, int]]:
 
     deltas = _get_deltas(rve)
     eps: float = 1.0e-3 * min(deltas)
-    minimum = np.zeros(_DIM_COUNT)
-    maximum = deltas
-    maximum[axis] = 0.
+    minimum = _get_min(rve)
+    maximum = _get_max(rve)
+    maximum[axis] = _get_min(rve)[axis]
 
     # Get all the entities on the surface m (minimum value on axis, i.e. Xm, Ym or Zm)
     for bounds_min, tag_min in _iter_bounding_boxes(minimum, maximum, eps):
         # Translate the minimal bounds into the maximum value on axis surface       
-        bounds_min[:, axis] += 1
+        bounds_min[:, axis] += _get_deltas(rve)[axis]
+
         # Get all the entities on the corresponding surface (i.e. Xp, Yp or Zp)        
         for bounds_max, tag_max in _iter_bounding_boxes(bounds_min[0], bounds_min[1], eps):
 

--- a/microgen/test_utils.py
+++ b/microgen/test_utils.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+def is_periodic(nodes_coords, tol=1e-8, dim=3) -> bool:
+    # bounding box
+    xmax = np.max(nodes_coords[:, 0])
+    xmin = np.min(nodes_coords[:, 0])
+    ymax = np.max(nodes_coords[:, 1])
+    ymin = np.min(nodes_coords[:, 1])
+    if dim == 3:
+        zmax = np.max(nodes_coords[:, 2])
+        zmin = np.min(nodes_coords[:, 2])
+
+    # extract face nodes
+    left = np.where(np.abs(nodes_coords[:, 0] - xmin) < tol)[0]
+    right = np.where(np.abs(nodes_coords[:, 0] - xmax) < tol)[0]
+
+    if dim > 1:
+        bottom = np.where(np.abs(nodes_coords[:, 1] - ymin) < tol)[0]
+        top = np.where(np.abs(nodes_coords[:, 1] - ymax) < tol)[0]
+
+    if dim > 2:  # or dim == 3
+        back = np.where(np.abs(nodes_coords[:, 2] - zmin) < tol)[0]
+        front = np.where(np.abs(nodes_coords[:, 2] - zmax) < tol)[0]
+
+        # sort adjacent faces to ensure node correspondance
+    if nodes_coords.shape[1] == 2:  # 2D mesh
+        left = left[np.argsort(nodes_coords[left, 1])]
+        right = right[np.argsort(nodes_coords[right, 1])]
+        if dim > 1:
+            bottom = bottom[np.argsort(nodes_coords[bottom, 0])]
+            top = top[np.argsort(nodes_coords[top, 0])]
+
+    elif nodes_coords.shape[1] > 2:
+        decimal_round = int(-np.log10(tol) - 1)
+        left = left[
+            np.lexsort(
+                (nodes_coords[left, 1], nodes_coords[left, 2].round(decimal_round))
+            )
+        ]
+        right = right[
+            np.lexsort(
+                (nodes_coords[right, 1], nodes_coords[right, 2].round(decimal_round))
+            )
+        ]
+        if dim > 1:
+            bottom = bottom[
+                np.lexsort(
+                    (
+                        nodes_coords[bottom, 0],
+                        nodes_coords[bottom, 2].round(decimal_round),
+                    )
+                )
+            ]
+            top = top[
+                np.lexsort(
+                    (nodes_coords[top, 0], nodes_coords[top, 2].round(decimal_round))
+                )
+            ]
+        if dim > 2:
+            back = back[
+                np.lexsort(
+                    (nodes_coords[back, 0], nodes_coords[back, 1].round(decimal_round))
+                )
+            ]
+            front = front[
+                np.lexsort(
+                    (
+                        nodes_coords[front, 0],
+                        nodes_coords[front, 1].round(decimal_round),
+                    )
+                )
+            ]
+
+    # ==========================
+    # test if mesh is periodic:
+    # ==========================
+
+    # test if same number of nodes in adjacent faces
+    if len(left) != len(right):
+        return False
+    if dim > 1 and len(bottom) != len(top):
+        return False
+    if dim > 2 and (len(back) != len(front)):
+        return False
+
+    # check nodes position
+    if (nodes_coords[right, 1:] - nodes_coords[left, 1:] > tol).any():
+        return False
+    if dim > 1 and (nodes_coords[top, ::2] - nodes_coords[bottom, ::2] > tol).any():
+        return False
+    if dim > 2 and (nodes_coords[front, :2] - nodes_coords[back, :2] > tol).any():
+        return False
+
+    return True

--- a/tests/test_is_periodic.py
+++ b/tests/test_is_periodic.py
@@ -1,0 +1,145 @@
+import pytest
+import numpy as np
+import numpy.typing as npt
+import pyvista as pv
+from microgen import is_periodic
+
+@pytest.fixture(scope='session')
+def periodic_box_nodes() -> npt.NDArray[np.float_]:
+    nodes_array = np.array([[0., 0., 0.],
+                            [0.5, 0.5, 0.5],
+                            [-0.5, -0.5, -0.5],
+                            [-0.5, -0.5, 0.5],
+                            [0.5, 0.5, -0.5],
+                            [0.5, -0.5, 0.5],
+                            [0.5, -0.5, -0.5],
+                            [-0.5, 0.5, 0.5],
+                            [-0.5, 0.5, -0.5],
+                            [0., 0.5, 0.],
+                            [0., -0.5, 0.],
+                            [0.5, 0., 0.],
+                            [-0.5, 0., 0.],
+                            [0., 0., 0.5],
+                            [0., 0., -0.5]])
+
+    return nodes_array
+
+@pytest.fixture(scope='session')
+def one_shifted_node_box_nodes() -> npt.NDArray[np.float_]:
+    nodes_array = np.array([[0., 0., 0.],
+                            [0.5, 0.5, 0.5],
+                            [-0.5, -0.5, -0.5],
+                            [-0.5, -0.5, 0.5],
+                            [0.5, 0.5, -0.5],
+                            [0.5, -0.5, 0.5],
+                            [0.5, -0.5, -0.5],
+                            [-0.5, 0.5, 0.5],
+                            [-0.5, 0.5, -0.5],
+                            [0., 0.5, 0.],
+                            [0., -0.5, 0.],
+                            [0.5, 0.1, 0.],
+                            [-0.5, 0., 0.],
+                            [0., 0., 0.5],
+                            [0., 0., -0.5]])
+
+    return nodes_array
+
+@pytest.fixture(scope='session')
+def box_elements_same_number_of_nodes() -> npt.NDArray[int]:
+    elements = np.array([[4, 11, 6, 0, 14],
+                                   [4, 0, 9, 1, 11],
+                                   [4, 3, 10, 0, 13],
+                                   [4, 9, 0, 4, 11],
+                                   [4, 5, 11, 0, 13],
+                                   [4, 0, 11, 1, 13],
+                                   [4, 0, 10, 5, 13],
+                                   [4, 11, 5, 1, 13],
+                                   [4, 3, 10, 2, 12],
+                                   [4, 6, 10, 0, 14],
+                                   [4, 1, 9, 4, 11],
+                                   [4, 10, 3, 0, 12],
+                                   [4, 10, 3, 5, 13],
+                                   [4, 0, 10, 2, 14],
+                                   [4, 2, 10, 0, 12],
+                                   [4, 4, 11, 0, 14],
+                                   [4, 6, 11, 4, 14],
+                                   [4, 10, 6, 2, 14],
+                                   [4, 5, 10, 0, 11],
+                                   [4, 0, 10, 6, 11],
+                                   [4, 10, 5, 6, 11],
+                                   [4, 7, 9, 0, 12],
+                                   [4, 0, 9, 8, 12],
+                                   [4, 9, 7, 8, 12],
+                                   [4, 7, 9, 1, 13],
+                                   [4, 1, 9, 0, 13],
+                                   [4, 9, 7, 0, 13],
+                                   [4, 0, 12, 3, 13],
+                                   [4, 3, 12, 7, 13],
+                                   [4, 12, 0, 7, 13],
+                                   [4, 8, 12, 2, 14],
+                                   [4, 2, 12, 0, 14],
+                                   [4, 12, 8, 0, 14],
+                                   [4, 8, 9, 0, 14],
+                                   [4, 0, 9, 4, 14],
+                                   [4, 9, 8, 4, 14]])
+
+    return elements
+
+@pytest.fixture(scope='session')
+def one_extra_node_box_nodes() -> npt.NDArray[np.float_]:
+    nodes_array = np.array([[0., 0., 0.],
+                            [0.5, 0.5, 0.5],
+                            [-0.5, -0.5, -0.5],
+                            [-0.5, -0.5, 0.5],
+                            [0.5, 0.5, -0.5],
+                            [0.5, -0.5, 0.5],
+                            [0.5, -0.5, -0.5],
+                            [-0.5, 0.5, 0.5],
+                            [-0.5, 0.5, -0.5],
+                            [0., 0.5, 0.],
+                            [0., -0.5, 0.],
+                            [0.5, 0., 0.],
+                            [-0.5, 0., 0.],
+                            [0., 0., 0.5],
+                            [0., 0., -0.5],
+                            [0.3, 0.2, -0.5]])
+
+    return nodes_array
+
+
+@pytest.fixture(scope="session")
+def periodic_box(periodic_box_nodes, box_elements_same_number_of_nodes):
+    celltypes = np.full(box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8)
+    grid = pv.UnstructuredGrid(box_elements_same_number_of_nodes, celltypes, periodic_box_nodes)
+
+    return grid
+
+@pytest.fixture(scope="session")
+def non_periodic_box_1_extra_node(one_extra_node_box_nodes):
+    points = one_extra_node_box_nodes
+    point_cloud = pv.PolyData(points)
+    grid = point_cloud.delaunay_3d(offset=100.)
+
+    return grid
+
+@pytest.fixture(scope="session")
+def non_periodic_box_shifted_node(one_shifted_node_box_nodes, box_elements_same_number_of_nodes):
+    celltypes = np.full(box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8)
+    grid = pv.UnstructuredGrid(box_elements_same_number_of_nodes, celltypes, one_shifted_node_box_nodes)
+
+    return grid
+
+def test_given_periodic_box_is_periodic_must_return_true(periodic_box):
+    crd = periodic_box.points
+
+    assert is_periodic(crd)
+
+def test_given_non_periodic_box_with_an_extra_node_is_periodic_must_return_false(non_periodic_box_1_extra_node):
+    crd = non_periodic_box_1_extra_node.points
+
+    assert not is_periodic(crd)
+
+def test_given_non_periodic_box_with_a_shifted_node_but_no_extra_node_is_periodic_must_return_false(non_periodic_box_shifted_node):
+    crd = non_periodic_box_shifted_node.points
+
+    assert not is_periodic(crd)

--- a/tests/test_is_periodic.py
+++ b/tests/test_is_periodic.py
@@ -4,142 +4,181 @@ import numpy.typing as npt
 import pyvista as pv
 from microgen import is_periodic
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def periodic_box_nodes() -> npt.NDArray[np.float_]:
-    nodes_array = np.array([[0., 0., 0.],
-                            [0.5, 0.5, 0.5],
-                            [-0.5, -0.5, -0.5],
-                            [-0.5, -0.5, 0.5],
-                            [0.5, 0.5, -0.5],
-                            [0.5, -0.5, 0.5],
-                            [0.5, -0.5, -0.5],
-                            [-0.5, 0.5, 0.5],
-                            [-0.5, 0.5, -0.5],
-                            [0., 0.5, 0.],
-                            [0., -0.5, 0.],
-                            [0.5, 0., 0.],
-                            [-0.5, 0., 0.],
-                            [0., 0., 0.5],
-                            [0., 0., -0.5]])
+    nodes_array = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.5],
+            [-0.5, -0.5, -0.5],
+            [-0.5, -0.5, 0.5],
+            [0.5, 0.5, -0.5],
+            [0.5, -0.5, 0.5],
+            [0.5, -0.5, -0.5],
+            [-0.5, 0.5, 0.5],
+            [-0.5, 0.5, -0.5],
+            [0.0, 0.5, 0.0],
+            [0.0, -0.5, 0.0],
+            [0.5, 0.0, 0.0],
+            [-0.5, 0.0, 0.0],
+            [0.0, 0.0, 0.5],
+            [0.0, 0.0, -0.5],
+        ]
+    )
 
     return nodes_array
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def one_shifted_node_box_nodes() -> npt.NDArray[np.float_]:
-    nodes_array = np.array([[0., 0., 0.],
-                            [0.5, 0.5, 0.5],
-                            [-0.5, -0.5, -0.5],
-                            [-0.5, -0.5, 0.5],
-                            [0.5, 0.5, -0.5],
-                            [0.5, -0.5, 0.5],
-                            [0.5, -0.5, -0.5],
-                            [-0.5, 0.5, 0.5],
-                            [-0.5, 0.5, -0.5],
-                            [0., 0.5, 0.],
-                            [0., -0.5, 0.],
-                            [0.5, 0.1, 0.],
-                            [-0.5, 0., 0.],
-                            [0., 0., 0.5],
-                            [0., 0., -0.5]])
+    nodes_array = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.5],
+            [-0.5, -0.5, -0.5],
+            [-0.5, -0.5, 0.5],
+            [0.5, 0.5, -0.5],
+            [0.5, -0.5, 0.5],
+            [0.5, -0.5, -0.5],
+            [-0.5, 0.5, 0.5],
+            [-0.5, 0.5, -0.5],
+            [0.0, 0.5, 0.0],
+            [0.0, -0.5, 0.0],
+            [0.5, 0.1, 0.0],
+            [-0.5, 0.0, 0.0],
+            [0.0, 0.0, 0.5],
+            [0.0, 0.0, -0.5],
+        ]
+    )
 
     return nodes_array
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def box_elements_same_number_of_nodes() -> npt.NDArray[int]:
-    elements = np.array([[4, 11, 6, 0, 14],
-                                   [4, 0, 9, 1, 11],
-                                   [4, 3, 10, 0, 13],
-                                   [4, 9, 0, 4, 11],
-                                   [4, 5, 11, 0, 13],
-                                   [4, 0, 11, 1, 13],
-                                   [4, 0, 10, 5, 13],
-                                   [4, 11, 5, 1, 13],
-                                   [4, 3, 10, 2, 12],
-                                   [4, 6, 10, 0, 14],
-                                   [4, 1, 9, 4, 11],
-                                   [4, 10, 3, 0, 12],
-                                   [4, 10, 3, 5, 13],
-                                   [4, 0, 10, 2, 14],
-                                   [4, 2, 10, 0, 12],
-                                   [4, 4, 11, 0, 14],
-                                   [4, 6, 11, 4, 14],
-                                   [4, 10, 6, 2, 14],
-                                   [4, 5, 10, 0, 11],
-                                   [4, 0, 10, 6, 11],
-                                   [4, 10, 5, 6, 11],
-                                   [4, 7, 9, 0, 12],
-                                   [4, 0, 9, 8, 12],
-                                   [4, 9, 7, 8, 12],
-                                   [4, 7, 9, 1, 13],
-                                   [4, 1, 9, 0, 13],
-                                   [4, 9, 7, 0, 13],
-                                   [4, 0, 12, 3, 13],
-                                   [4, 3, 12, 7, 13],
-                                   [4, 12, 0, 7, 13],
-                                   [4, 8, 12, 2, 14],
-                                   [4, 2, 12, 0, 14],
-                                   [4, 12, 8, 0, 14],
-                                   [4, 8, 9, 0, 14],
-                                   [4, 0, 9, 4, 14],
-                                   [4, 9, 8, 4, 14]])
+    elements = np.array(
+        [
+            [4, 11, 6, 0, 14],
+            [4, 0, 9, 1, 11],
+            [4, 3, 10, 0, 13],
+            [4, 9, 0, 4, 11],
+            [4, 5, 11, 0, 13],
+            [4, 0, 11, 1, 13],
+            [4, 0, 10, 5, 13],
+            [4, 11, 5, 1, 13],
+            [4, 3, 10, 2, 12],
+            [4, 6, 10, 0, 14],
+            [4, 1, 9, 4, 11],
+            [4, 10, 3, 0, 12],
+            [4, 10, 3, 5, 13],
+            [4, 0, 10, 2, 14],
+            [4, 2, 10, 0, 12],
+            [4, 4, 11, 0, 14],
+            [4, 6, 11, 4, 14],
+            [4, 10, 6, 2, 14],
+            [4, 5, 10, 0, 11],
+            [4, 0, 10, 6, 11],
+            [4, 10, 5, 6, 11],
+            [4, 7, 9, 0, 12],
+            [4, 0, 9, 8, 12],
+            [4, 9, 7, 8, 12],
+            [4, 7, 9, 1, 13],
+            [4, 1, 9, 0, 13],
+            [4, 9, 7, 0, 13],
+            [4, 0, 12, 3, 13],
+            [4, 3, 12, 7, 13],
+            [4, 12, 0, 7, 13],
+            [4, 8, 12, 2, 14],
+            [4, 2, 12, 0, 14],
+            [4, 12, 8, 0, 14],
+            [4, 8, 9, 0, 14],
+            [4, 0, 9, 4, 14],
+            [4, 9, 8, 4, 14],
+        ]
+    )
 
     return elements
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def one_extra_node_box_nodes() -> npt.NDArray[np.float_]:
-    nodes_array = np.array([[0., 0., 0.],
-                            [0.5, 0.5, 0.5],
-                            [-0.5, -0.5, -0.5],
-                            [-0.5, -0.5, 0.5],
-                            [0.5, 0.5, -0.5],
-                            [0.5, -0.5, 0.5],
-                            [0.5, -0.5, -0.5],
-                            [-0.5, 0.5, 0.5],
-                            [-0.5, 0.5, -0.5],
-                            [0., 0.5, 0.],
-                            [0., -0.5, 0.],
-                            [0.5, 0., 0.],
-                            [-0.5, 0., 0.],
-                            [0., 0., 0.5],
-                            [0., 0., -0.5],
-                            [0.3, 0.2, -0.5]])
+    nodes_array = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.5],
+            [-0.5, -0.5, -0.5],
+            [-0.5, -0.5, 0.5],
+            [0.5, 0.5, -0.5],
+            [0.5, -0.5, 0.5],
+            [0.5, -0.5, -0.5],
+            [-0.5, 0.5, 0.5],
+            [-0.5, 0.5, -0.5],
+            [0.0, 0.5, 0.0],
+            [0.0, -0.5, 0.0],
+            [0.5, 0.0, 0.0],
+            [-0.5, 0.0, 0.0],
+            [0.0, 0.0, 0.5],
+            [0.0, 0.0, -0.5],
+            [0.3, 0.2, -0.5],
+        ]
+    )
 
     return nodes_array
 
 
 @pytest.fixture(scope="session")
 def periodic_box(periodic_box_nodes, box_elements_same_number_of_nodes):
-    celltypes = np.full(box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8)
-    grid = pv.UnstructuredGrid(box_elements_same_number_of_nodes, celltypes, periodic_box_nodes)
+    celltypes = np.full(
+        box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8
+    )
+    grid = pv.UnstructuredGrid(
+        box_elements_same_number_of_nodes, celltypes, periodic_box_nodes
+    )
 
     return grid
+
 
 @pytest.fixture(scope="session")
 def non_periodic_box_1_extra_node(one_extra_node_box_nodes):
     points = one_extra_node_box_nodes
     point_cloud = pv.PolyData(points)
-    grid = point_cloud.delaunay_3d(offset=100.)
+    grid = point_cloud.delaunay_3d(offset=100.0)
 
     return grid
+
 
 @pytest.fixture(scope="session")
-def non_periodic_box_shifted_node(one_shifted_node_box_nodes, box_elements_same_number_of_nodes):
-    celltypes = np.full(box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8)
-    grid = pv.UnstructuredGrid(box_elements_same_number_of_nodes, celltypes, one_shifted_node_box_nodes)
+def non_periodic_box_shifted_node(
+    one_shifted_node_box_nodes, box_elements_same_number_of_nodes
+):
+    celltypes = np.full(
+        box_elements_same_number_of_nodes.shape[0], pv.CellType.TETRA, dtype=np.uint8
+    )
+    grid = pv.UnstructuredGrid(
+        box_elements_same_number_of_nodes, celltypes, one_shifted_node_box_nodes
+    )
 
     return grid
+
 
 def test_given_periodic_box_is_periodic_must_return_true(periodic_box):
     crd = periodic_box.points
 
     assert is_periodic(crd)
 
-def test_given_non_periodic_box_with_an_extra_node_is_periodic_must_return_false(non_periodic_box_1_extra_node):
+
+def test_given_non_periodic_box_with_an_extra_node_is_periodic_must_return_false(
+    non_periodic_box_1_extra_node,
+):
     crd = non_periodic_box_1_extra_node.points
 
     assert not is_periodic(crd)
 
-def test_given_non_periodic_box_with_a_shifted_node_but_no_extra_node_is_periodic_must_return_false(non_periodic_box_shifted_node):
+
+def test_given_non_periodic_box_with_a_shifted_node_but_no_extra_node_is_periodic_must_return_false(
+    non_periodic_box_shifted_node,
+):
     crd = non_periodic_box_shifted_node.points
 
     assert not is_periodic(crd)

--- a/tests/test_meshPeriodic.py
+++ b/tests/test_meshPeriodic.py
@@ -2,33 +2,22 @@ from microgen import Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, mesh
 import cadquery as cq
 import pyvista as pv
 import numpy as np
+import os
 from typing import Union
 import pytest
-from pathlib import Path
 
 @pytest.fixture(scope='function')
 def rve() -> Rve:
     return Rve(dim_x=1, dim_y=1, dim_z=1, center=(0.5, 0.5, 0.5))
-
-@pytest.fixture(scope="function")
-def tmp_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    tmp_dir_name = "test_tmp_dir"
-    return tmp_path_factory.mktemp(tmp_dir_name)
-
-@pytest.fixture(scope="function")
-def tmp_output_compound_filename(tmp_dir: Path) -> str:
-    return (tmp_dir / "compound.step").as_posix()
-
-@pytest.fixture(scope="function")
-def tmp_output_vtk_filename(tmp_dir: Path) -> str:
-    return (tmp_dir / "octettruss.vtk").as_posix()
 
 @pytest.mark.filterwarnings("ignore:Object intersecting")
 def _generate_cqcompound_octettruss(
     rve: Rve
 ):
 
-    #data to generate octet truss cylinders
+        # précision du type des données
+    number = [1,2,3,4,5,6,7,8,9]
+    shape = 'cylinder'
     xc = np.array([0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0])
     yc = np.array([0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5])
     zc = np.array([0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5])
@@ -38,8 +27,8 @@ def _generate_cqcompound_octettruss(
     height = np.full_like(xc, 2.0)
     radius = np.full_like(xc, 0.05)
 
-    listPhases : list[Phase] = []
-    listPeriodicPhases : list[Phase] = []
+    listPhases = []  # type: list[microgen.Phase]
+    listPeriodicPhases = []  # type: list[microgen.Phase]
     n = len(xc)
 
     for i in range(0, n):
@@ -80,28 +69,23 @@ def octet_truss_heterogeneous(rve : Rve) -> (cq.Compound, list[Phase]):
         "octet_truss_heterogeneous",
     ]
 )
-def test_octettruss_mesh_must_be_periodic(
-    shape: Union[cq.Compound, cq.Shape],
-    request, 
-    rve: Rve,
-    tmp_output_compound_filename: str,
-    tmp_output_vtk_filename: str
-):
+def test_octettruss_mesh_must_be_periodic(shape: Union[cq.Compound, cq.Shape], request, rve: Rve):
 
     cqoctet, listcqphases = request.getfixturevalue(shape)
 
-    cq.exporters.export(cqoctet, tmp_output_compound_filename)
+    os.makedirs("tests/data", exist_ok=True)  # if data folder doesn't exist yet
+    cq.exporters.export(cqoctet, "tests/data/compound.step")
     meshPeriodic(
-        mesh_file=tmp_output_compound_filename,
+        mesh_file="tests/data/compound.step",
         rve=rve,
         listPhases=listcqphases,
         size=0.03,
         order=1,
-        output_file=tmp_output_vtk_filename,
+        output_file="tests/data/octettruss.vtk",
     )
 
     #Act
-    pvmesh = pv.read(tmp_output_vtk_filename)  
+    pvmesh = pv.read('tests/data/octettruss.vtk')  
     crd = pvmesh.points
 
     assert is_periodic(crd)    

--- a/tests/test_meshPeriodic.py
+++ b/tests/test_meshPeriodic.py
@@ -1,4 +1,14 @@
-from microgen import Box, Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, meshPeriodic, is_periodic
+from microgen import (
+    Box,
+    Rve,
+    Phase,
+    Cylinder,
+    periodic,
+    fuseShapes,
+    cutPhases,
+    meshPeriodic,
+    is_periodic,
+)
 import cadquery as cq
 import pyvista as pv
 import numpy as np
@@ -6,48 +16,58 @@ from typing import Union
 import pytest
 from pathlib import Path
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def rve_unit() -> Rve:
     return Rve(dim_x=1, dim_y=1, dim_z=1, center=(0.5, 0.5, 0.5))
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def rve_double() -> Rve:
     return Rve(dim_x=2, dim_y=2, dim_z=2, center=(1.0, 1.0, 1.0))
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def rve_double_centered() -> Rve:
     return Rve(dim_x=2, dim_y=2, dim_z=2, center=(0.0, 0.0, 0.0))
+
 
 @pytest.fixture(scope="function")
 def tmp_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     tmp_dir_name = "test_tmp_dir"
     return tmp_path_factory.mktemp(tmp_dir_name)
 
+
 @pytest.fixture(scope="function")
 def tmp_output_compound_filename(tmp_dir: Path) -> str:
     return (tmp_dir / "compound.step").as_posix()
+
 
 @pytest.fixture(scope="function")
 def tmp_output_vtk_filename(tmp_dir: Path) -> str:
     return (tmp_dir / "octettruss.vtk").as_posix()
 
-@pytest.mark.filterwarnings("ignore:Object intersecting")
-def _generate_cqcompound_octettruss(
-    rve: Rve
-):
 
-    #data to generate octet truss cylinders
-    xc = np.array([0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0])
-    yc = np.array([0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5])
-    zc = np.array([0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5])
-    psi = np.array([45.,-45.,0.,0.,90.,90.,0.,0.,90.,90.,45.,-45.])
-    theta = np.array([0.,0.,-90.,-90.,-90.,-90.,90.,90.,90.,90.,0.,0.])
-    phi = np.array([0.,0.,45.,-45.,45.,-45.,-45.,45.,-45.,45.,0.,0.])
+@pytest.mark.filterwarnings("ignore:Object intersecting")
+def _generate_cqcompound_octettruss(rve: Rve):
+    # data to generate octet truss cylinders
+    xc = np.array([0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 0.0, 0.0])
+    yc = np.array([0.5, 0.5, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.5, 0.5])
+    zc = np.array([0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5])
+    psi = np.array(
+        [45.0, -45.0, 0.0, 0.0, 90.0, 90.0, 0.0, 0.0, 90.0, 90.0, 45.0, -45.0]
+    )
+    theta = np.array(
+        [0.0, 0.0, -90.0, -90.0, -90.0, -90.0, 90.0, 90.0, 90.0, 90.0, 0.0, 0.0]
+    )
+    phi = np.array(
+        [0.0, 0.0, 45.0, -45.0, 45.0, -45.0, -45.0, 45.0, -45.0, 45.0, 0.0, 0.0]
+    )
     height = np.full_like(xc, 2.0)
     radius = np.full_like(xc, 0.05)
 
-    listPhases : list[Phase] = []
-    listPeriodicPhases : list[Phase] = []
+    listPhases: list[Phase] = []
+    listPeriodicPhases: list[Phase] = []
     n = len(xc)
 
     for i in range(0, n):
@@ -66,49 +86,80 @@ def _generate_cqcompound_octettruss(
 
     return listPeriodicPhases
 
-@pytest.fixture(scope="function")
-def box_homogeneous_unit(rve_unit : Rve) -> (cq.Shape, list[Phase]):
 
-    shape = Box(center=rve_unit.center, orientation=(0.0, 0.0, 0.0), dim_x=rve_unit.dim_x, dim_y=rve_unit.dim_y, dim_z=rve_unit.dim_z).generate()
-    listcqphases = [Phase(shape=shape)]    
+@pytest.fixture(scope="function")
+def box_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, list[Phase]):
+    shape = Box(
+        center=rve_unit.center,
+        orientation=(0.0, 0.0, 0.0),
+        dim_x=rve_unit.dim_x,
+        dim_y=rve_unit.dim_y,
+        dim_z=rve_unit.dim_z,
+    ).generate()
+    listcqphases = [Phase(shape=shape)]
     return (shape, listcqphases, rve_unit)
 
-@pytest.fixture(scope="function")
-def box_homogeneous_double(rve_double : Rve) -> (cq.Shape, list[Phase]):
 
-    shape = Box(center=rve_double.center, orientation=(0.0, 0.0, 0.0), dim_x=rve_double.dim_x, dim_y=rve_double.dim_y, dim_z=rve_double.dim_z).generate()
-    listcqphases = [Phase(shape=shape)]    
+@pytest.fixture(scope="function")
+def box_homogeneous_double(rve_double: Rve) -> (cq.Shape, list[Phase]):
+    shape = Box(
+        center=rve_double.center,
+        orientation=(0.0, 0.0, 0.0),
+        dim_x=rve_double.dim_x,
+        dim_y=rve_double.dim_y,
+        dim_z=rve_double.dim_z,
+    ).generate()
+    listcqphases = [Phase(shape=shape)]
     return (shape, listcqphases, rve_double)
 
-@pytest.fixture(scope="function")
-def box_homogeneous_double_centered(rve_double_centered : Rve) -> (cq.Shape, list[Phase]):
 
-    shape = Box(center=rve_double_centered.center, orientation=(0.0, 0.0, 0.0), dim_x=rve_double_centered.dim_x, dim_y=rve_double_centered.dim_y, dim_z=rve_double_centered.dim_z).generate()
-    listcqphases = [Phase(shape=shape)]    
+@pytest.fixture(scope="function")
+def box_homogeneous_double_centered(
+    rve_double_centered: Rve,
+) -> (cq.Shape, list[Phase]):
+    shape = Box(
+        center=rve_double_centered.center,
+        orientation=(0.0, 0.0, 0.0),
+        dim_x=rve_double_centered.dim_x,
+        dim_y=rve_double_centered.dim_y,
+        dim_z=rve_double_centered.dim_z,
+    ).generate()
+    listcqphases = [Phase(shape=shape)]
     return (shape, listcqphases, rve_double_centered)
 
-@pytest.fixture(scope="function")
-def octet_truss_homogeneous_unit(rve_unit : Rve) -> (cq.Shape, list[Phase]):
 
+@pytest.fixture(scope="function")
+def octet_truss_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, list[Phase]):
     listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
-    merged = fuseShapes([phase.shape for phase in listPeriodicPhases], retain_edges=False)
-    listcqphases = [Phase(shape=merged)]    
+    merged = fuseShapes(
+        [phase.shape for phase in listPeriodicPhases], retain_edges=False
+    )
+    listcqphases = [Phase(shape=merged)]
     return (merged, listcqphases, rve_unit)
 
-@pytest.fixture(scope="function")
-def octet_truss_homogeneous_double_centered(rve_double_centered : Rve) -> (cq.Shape, list[Phase]):
 
+@pytest.fixture(scope="function")
+def octet_truss_homogeneous_double_centered(
+    rve_double_centered: Rve,
+) -> (cq.Shape, list[Phase]):
     listPeriodicPhases = _generate_cqcompound_octettruss(rve_double_centered)
-    merged = fuseShapes([phase.shape for phase in listPeriodicPhases], retain_edges=False)
-    listcqphases = [Phase(shape=merged)]    
+    merged = fuseShapes(
+        [phase.shape for phase in listPeriodicPhases], retain_edges=False
+    )
+    listcqphases = [Phase(shape=merged)]
     return (merged, listcqphases, rve_double_centered)
 
-@pytest.fixture(scope="function")
-def octet_truss_heterogeneous(rve_unit : Rve) -> (cq.Compound, list[Phase]):
 
-    listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)    
+@pytest.fixture(scope="function")
+def octet_truss_heterogeneous(rve_unit: Rve) -> (cq.Compound, list[Phase]):
+    listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
     listcqphases = cutPhases(phaseList=listPeriodicPhases, reverseOrder=False)
-    return (cq.Compound.makeCompound([phase.shape for phase in listcqphases]), listcqphases, rve_unit)
+    return (
+        cq.Compound.makeCompound([phase.shape for phase in listcqphases]),
+        listcqphases,
+        rve_unit,
+    )
+
 
 @pytest.mark.parametrize(
     "shape",
@@ -123,11 +174,10 @@ def octet_truss_heterogeneous(rve_unit : Rve) -> (cq.Compound, list[Phase]):
 )
 def test_octettruss_mesh_must_be_periodic(
     shape: Union[cq.Compound, cq.Shape],
-    request, 
+    request,
     tmp_output_compound_filename: str,
-    tmp_output_vtk_filename: str
+    tmp_output_vtk_filename: str,
 ):
-    
     cqoctet, listcqphases, rve = request.getfixturevalue(shape)
 
     cq.exporters.export(cqoctet, tmp_output_compound_filename)
@@ -140,8 +190,8 @@ def test_octettruss_mesh_must_be_periodic(
         output_file=tmp_output_vtk_filename,
     )
 
-    #Act
-    pvmesh = pv.read(tmp_output_vtk_filename)  
+    # Act
+    pvmesh = pv.read(tmp_output_vtk_filename)
     crd = pvmesh.points
 
-    assert is_periodic(crd)    
+    assert is_periodic(crd)

--- a/tests/test_meshPeriodic.py
+++ b/tests/test_meshPeriodic.py
@@ -1,4 +1,4 @@
-from microgen import Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, meshPeriodic, is_periodic
+from microgen import Box, Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, meshPeriodic, is_periodic
 import cadquery as cq
 import pyvista as pv
 import numpy as np
@@ -59,6 +59,13 @@ def _generate_cqcompound_octettruss(
     return listPeriodicPhases
 
 @pytest.fixture(scope="function")
+def box_homogeneous(rve : Rve) -> (cq.Shape, list[Phase]):
+
+    shape = Box(center=rve.center, orientation=(0.0, 0.0, 0.0), dim_x=rve.dim_x, dim_y=rve.dim_y, dim_z=rve.dim_z).generate()
+    listcqphases = [Phase(shape=shape)]    
+    return (shape, listcqphases)
+
+@pytest.fixture(scope="function")
 def octet_truss_homogeneous(rve : Rve) -> (cq.Shape, list[Phase]):
 
     listPeriodicPhases = _generate_cqcompound_octettruss(rve)
@@ -76,6 +83,7 @@ def octet_truss_heterogeneous(rve : Rve) -> (cq.Compound, list[Phase]):
 @pytest.mark.parametrize(
     "shape",
     [
+        "box_homogeneous"
         "octet_truss_homogeneous",
         "octet_truss_heterogeneous",
     ]

--- a/tests/test_meshPeriodic.py
+++ b/tests/test_meshPeriodic.py
@@ -83,7 +83,7 @@ def octet_truss_heterogeneous(rve : Rve) -> (cq.Compound, list[Phase]):
 @pytest.mark.parametrize(
     "shape",
     [
-        "box_homogeneous"
+        "box_homogeneous",
         "octet_truss_homogeneous",
         "octet_truss_heterogeneous",
     ]

--- a/tests/test_octettruss.py
+++ b/tests/test_octettruss.py
@@ -10,6 +10,19 @@ import pytest
 def rve() -> Rve:
     return Rve(dim_x=1, dim_y=1, dim_z=1, center=(0.5, 0.5, 0.5))
 
+@pytest.fixture(scope="function")
+def tmp_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_dir_name = "test_tmp_dir"
+    return tmp_path_factory.mktemp(tmp_dir_name)
+
+@pytest.fixture(scope="function")
+def tmp_output_compound_filename(tmp_dir: Path) -> str:
+    return (tmp_dir / "compound.step").as_posix()
+
+@pytest.fixture(scope="function")
+def tmp_output_vtk_filename(tmp_dir: Path) -> str:
+    return (tmp_dir / "octettruss.vtk").as_posix()
+
 @pytest.mark.filterwarnings("ignore:Object intersecting")
 def _generate_cqcompound_octettruss(
     rve: Rve
@@ -67,23 +80,28 @@ def octet_truss_heterogeneous(rve : Rve) -> (cq.Compound, list[Phase]):
         "octet_truss_heterogeneous",
     ]
 )
-def test_octettruss_mesh_must_be_periodic(shape: Union[cq.Compound, cq.Shape], request, rve: Rve):
+def test_octettruss_mesh_must_be_periodic(
+    shape: Union[cq.Compound, cq.Shape],
+    request, 
+    rve: Rve,
+    tmp_output_compound_filename: str,
+    tmp_output_vtk_filename: str
+):
 
     cqoctet, listcqphases = request.getfixturevalue(shape)
 
-    os.makedirs("tests/data", exist_ok=True)  # if data folder doesn't exist yet
-    cq.exporters.export(cqoctet, "tests/data/compound.step")
+    cq.exporters.export(cqoctet, tmp_output_compound_filename)
     meshPeriodic(
-        mesh_file="tests/data/compound.step",
+        mesh_file=tmp_output_compound_filename,
         rve=rve,
         listPhases=listcqphases,
         size=0.03,
         order=1,
-        output_file="tests/data/octettruss.vtk",
+        output_file=tmp_output_vtk_filename,
     )
 
     #Act
-    pvmesh = pv.read('tests/data/octettruss.vtk')  
+    pvmesh = pv.read(tmp_output_vtk_filename)  
     crd = pvmesh.points
 
     assert is_periodic(crd)    

--- a/tests/test_octettruss.py
+++ b/tests/test_octettruss.py
@@ -38,8 +38,8 @@ def _generate_cqcompound_octettruss(
     height = np.full_like(xc, 2.0)
     radius = np.full_like(xc, 0.05)
 
-    listPhases = []  # type: list[microgen.Phase]
-    listPeriodicPhases = []  # type: list[microgen.Phase]
+    listPhases : list[Phase] = []
+    listPeriodicPhases : list[Phase] = []
     n = len(xc)
 
     for i in range(0, n):

--- a/tests/test_octettruss.py
+++ b/tests/test_octettruss.py
@@ -2,9 +2,9 @@ from microgen import Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, mesh
 import cadquery as cq
 import pyvista as pv
 import numpy as np
-import os
 from typing import Union
 import pytest
+from pathlib import Path
 
 @pytest.fixture(scope='function')
 def rve() -> Rve:

--- a/tests/test_octettruss.py
+++ b/tests/test_octettruss.py
@@ -1,78 +1,89 @@
-import microgen
+from microgen import Rve, Phase, Cylinder, periodic, fuseShapes, cutPhases, meshPeriodic, is_periodic
 import cadquery as cq
+import pyvista as pv
 import numpy as np
 import os
-
+from typing import Union
 import pytest
 
+@pytest.fixture(scope='function')
+def rve() -> Rve:
+    return Rve(dim_x=1, dim_y=1, dim_z=1, center=(0.5, 0.5, 0.5))
 
 @pytest.mark.filterwarnings("ignore:Object intersecting")
-def test_octettruss():
+def _generate_cqcompound_octettruss(
+    rve: Rve
+):
 
-    # fichier
-    NPhases_file = "examples/Lattices/octetTruss/test_octet.dat"
+    #data to generate octet truss cylinders
+    xc = np.array([0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0])
+    yc = np.array([0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5])
+    zc = np.array([0.0,0.0,0.5,0.5,0.5,0.5,0.0,0.0,0.5,0.5,0.5,0.5])
+    psi = np.array([45.,-45.,0.,0.,90.,90.,0.,0.,90.,90.,45.,-45.])
+    theta = np.array([0.,0.,-90.,-90.,-90.,-90.,90.,90.,90.,90.,0.,0.])
+    phi = np.array([0.,0.,45.,-45.,45.,-45.,-45.,45.,-45.,45.,0.,0.])
+    height = np.full_like(xc, 2.0)
+    radius = np.full_like(xc, 0.05)
 
-    dt = np.dtype(
-        [
-            ("number", int),
-            ("shape", np.str_, 10),
-            ("xc", np.float64),
-            ("yc", np.float64),
-            ("zc", np.float64),
-            ("psi", np.float64),
-            ("theta", np.float64),
-            ("phi", np.float64),
-            ("height", np.float64),
-            ("radius", np.float64),
-        ]
-    )
-    # précision du type des données
-    number, shape, xc, yc, zc, psi, theta, phi, height, radius, = np.loadtxt(
-        NPhases_file,
-        dtype=dt,
-        usecols=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
-        skiprows=1,
-        unpack=True,
-        ndmin=1,
-    )
-
-    revel = microgen.Rve(dim_x=1, dim_y=1, dim_z=1, center=(0.5, 0.5, 0.5))
     listPhases = []  # type: list[microgen.Phase]
     listPeriodicPhases = []  # type: list[microgen.Phase]
     n = len(xc)
 
     for i in range(0, n):
-        elem = microgen.shape.cylinder.Cylinder(
+        elem = Cylinder(
             center=(xc[i], yc[i], zc[i]),
             orientation=(psi[i], theta[i], phi[i]),
             height=height[i],
             radius=radius[i],
         )
-        phase = microgen.Phase(shape=elem.generate())
+        phase = Phase(shape=elem.generate())
         listPhases.append(phase)
 
     for phase_elem in listPhases:
-        periodicPhase = microgen.periodic(phase=phase_elem, rve=revel)
+        periodicPhase = periodic(phase=phase_elem, rve=rve)
         listPeriodicPhases.append(periodicPhase)
 
-    print([phase.centerOfMass for phase in listPeriodicPhases])
+    return listPeriodicPhases
 
-    phases_cut = microgen.cutPhases(phaseList=listPeriodicPhases, reverseOrder=True)
-    phases_cut = microgen.cutPhases(phaseList=listPeriodicPhases, reverseOrder=False)
-    compound = cq.Compound.makeCompound([phase.shape for phase in phases_cut])
+@pytest.fixture(scope="function")
+def octet_truss_homogeneous(rve : Rve) -> (cq.Shape, list[Phase]):
+
+    listPeriodicPhases = _generate_cqcompound_octettruss(rve)
+    merged = fuseShapes([phase.shape for phase in listPeriodicPhases], retain_edges=False)
+    listcqphases = [Phase(shape=merged)]    
+    return (merged, listcqphases)
+
+@pytest.fixture(scope="function")
+def octet_truss_heterogeneous(rve : Rve) -> (cq.Compound, list[Phase]):
+
+    listPeriodicPhases = _generate_cqcompound_octettruss(rve)    
+    listcqphases = cutPhases(phaseList=listPeriodicPhases, reverseOrder=False)
+    return (cq.Compound.makeCompound([phase.shape for phase in listcqphases]), listcqphases)
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        "octet_truss_homogeneous",
+        "octet_truss_heterogeneous",
+    ]
+)
+def test_octettruss_mesh_must_be_periodic(shape: Union[cq.Compound, cq.Shape], request, rve: Rve):
+
+    cqoctet, listcqphases = request.getfixturevalue(shape)
 
     os.makedirs("tests/data", exist_ok=True)  # if data folder doesn't exist yet
-
-    cq.exporters.export(compound, "tests/data/compound.step")
-    microgen.meshPeriodic(
+    cq.exporters.export(cqoctet, "tests/data/compound.step")
+    meshPeriodic(
         mesh_file="tests/data/compound.step",
-        rve=revel,
-        listPhases=phases_cut,
+        rve=rve,
+        listPhases=listcqphases,
         size=0.03,
         order=1,
-        output_file="tests/data/MeshPeriodic.vtk",
+        output_file="tests/data/octettruss.vtk",
     )
 
+    #Act
+    pvmesh = pv.read('tests/data/octettruss.vtk')  
+    crd = pvmesh.points
 
-if __name__ == "__main__":
-    test_octettruss()
+    assert is_periodic(crd)    


### PR DESCRIPTION
### Overview

Fixes bug #25 

### Details

Essentially removed the line :             `bounds_max[:, axis] -= 1 in mesh.py` since `bounds_min` has been modified
Add test for an octet truss structure using two type of generation
