### PR TITLE
Add doc workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,11 +28,10 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt-get install libglu1-mesa
 
-      - name: Install uv
-        run: pip install uv
-
       - name: Install
-        run: uv pip install --system microgen@. pytest pytest-xdist
+        run: |
+          pip install uv
+          uv pip install --system microgen@. pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,14 +12,15 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install uv
 
       - name: Install
-        run: uv pip install "microgen @ ." pytest pytest-xdist
+        run: uv pip install --system microgen@. pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,11 +28,14 @@ jobs:
       - if: runner.os == 'Linux'
         run: sudo apt-get install libglu1-mesa
 
+      - name: Install uv
+        run: pip install uv
+
       - name: Install
-        run: pip install .[dev]
+        run: uv pip install . pytest pytest-xdist
 
       - name: Test
-        run: pytest tests --cov-report term-missing --cov=microgen --numprocesses=auto
+        run: pytest tests --numprocesses=auto
 
       - name: Examples
         if: runner.os != 'Windows'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install uv
 
       - name: Install
-        run: uv pip install . pytest pytest-xdist
+        run: uv pip install "microgen @ ." pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build Documentation
 
 on:
   push:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,13 +24,14 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
-        with:
-          packages: libosmesa6-dev libgl1-mesa-dev python3-tk
-          version: 3.0
+      - name: Install libGLU
+        run: sudo apt-get install libglu1-mesa
 
       - name: Install
         run: pip install .[docs]
+
+      - name: Install vtk
+        run: pip uninstall vtk -y && pip install vtk-osmesa --extra-index-url https://wheels.vtk.org
 
       - name: Build docs
         run: make -C docs html

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,6 +20,9 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Install libGLU
+        run: sudo apt-get install libglu1-mesa
+
       - name: Install
         run: pip install .[docs]
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   build-and-test:
     runs-on: "ubuntu-latest"
+    env:
+      PYVISTA_OFF_SCREEN: "True"
+      ALLOW_PLOTTING: true
+      SHELLOPTS: "errexit:pipefail"
 
     steps:
       - uses: actions/checkout@v4
@@ -20,8 +24,10 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
-      - name: Install libGLU
-        run: sudo apt-get install libglu1-mesa
+      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+        with:
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk
+          version: 3.0
 
       - name: Install
         run: pip install .[docs]

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,27 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - "*"
+
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build-and-test:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install
+        run: pip install .[docs]
+
+      - name: Build docs
+        run: make -C docs html


### PR DESCRIPTION
This PR adds a workflow to check if the documentation builds without problems.
The `fail-fast: false` option is added to the "Build and Test" workflow to avoid cancelling all the workflows if one doesn't pass.
Finally the versions of the actions `checkout` and `setup-python` have been updated.

Edit: Test workflow now installs only required dependencies and use [uv](https://github.com/astral-sh/uv) to install faster.