### PR TITLE
Add MmgError exception raise when a mmg command fails

### DIFF
--- a/microgen/external.py
+++ b/microgen/external.py
@@ -485,6 +485,12 @@ def parseNeper(filename: str) -> tuple:
     return A, seed, listeSommetsOut, edges, faces, polys
 
 
+class MmgError(Exception):
+    """Raised when Mmg command fails"""
+
+    ...
+
+
 class Mmg:
     @staticmethod
     def mmg2d(
@@ -614,11 +620,8 @@ class Mmg:
 
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            print(
-                "mmg command did not work, check if it is installed or contact a developer"
-            )
-            return
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise MmgError(f"mmg command {cmd} failed") from error
 
     @staticmethod
     def mmgs(
@@ -733,11 +736,8 @@ class Mmg:
 
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            print(
-                "mmg command did not work, check if it is installed or contact a developer"
-            )
-            return
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise MmgError(f"mmg command {cmd} failed") from error
 
     @staticmethod
     def mmg3d(
@@ -875,8 +875,5 @@ class Mmg:
 
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            print(
-                "mmg command did not work, check if it is installed or contact a developer"
-            )
-            return
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise MmgError(f"mmg command {cmd} failed") from error

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,0 +1,18 @@
+import microgen
+import pytest
+from microgen.external import MmgError
+
+
+def test_run_mmg2d_with_no_arguments_must_raise_MmgError() -> None:
+    with pytest.raises(MmgError):
+        microgen.external.Mmg.mmg2d()
+
+
+def test_run_mmgs_with_no_arguments_must_raise_MmgError() -> None:
+    with pytest.raises(MmgError):
+        microgen.external.Mmg.mmgs()
+
+
+def test_run_mmg3d_with_no_arguments_must_raise_MmgError() -> None:
+    with pytest.raises(MmgError):
+        microgen.external.Mmg.mmgs()


### PR DESCRIPTION
Before this pull request exceptions raised by Mmg calls were completely silent, the idea is to raise an exception of type `MmgError`that recalls the original causing exception which can be `subprocess.CalledProcessError` or `FileNotFoundError`

A minimal test case when no arguments are passed to mmg call is added in `test_external.py`