### PR TITLE
Remove 'max' density and fix bounds to compute offset from density

### DIFF
--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -139,10 +139,6 @@ class Tpms(BasicGeometry):
     ) -> None:
         if self.density is None:
             raise ValueError("density must be given to compute offset")
-        temp_tpms = Tpms(
-            surface_function=self.surface_function,
-            resolution=resolution if resolution is not None else self.resolution,
-        )
 
         min_field = np.min(self.grid["surface"])
         max_field = np.max(self.grid["surface"])
@@ -158,13 +154,15 @@ class Tpms(BasicGeometry):
             self._update_offset(offset)
             return
 
-        grid_volume = temp_tpms.grid.volume
-
+        temp_tpms = Tpms(
+            surface_function=self.surface_function,
+            resolution=resolution if resolution is not None else self.resolution,
+        )
         polydata_func = getattr(temp_tpms, f"vtk_{part_type.replace(' ', '_')}")
 
         def density(offset: float) -> float:
             temp_tpms._update_offset(offset)
-            return polydata_func().volume / grid_volume
+            return polydata_func().volume
 
         computed_offset = root_scalar(
             lambda offset: density(offset) - self.density,

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -496,6 +496,7 @@ class Tpms(BasicGeometry):
         smoothing: int = 0,
         verbose: bool = True,
         algo_resolution: Optional[int] = None,
+        compute_density: bool = False,
         **kwargs,
     ) -> cq.Shape:
         """
@@ -536,7 +537,7 @@ class Tpms(BasicGeometry):
 
         shape = self._extract_part_from_box(type_part, eps, smoothing, verbose)
 
-        if verbose:
+        if compute_density:
             density = shape.Volume() / (
                 np.prod(self.repeat_cell) * np.prod(self.cell_size)
             )
@@ -557,7 +558,7 @@ class Tpms(BasicGeometry):
             "sheet", "lower skeletal", "upper skeletal", "surface"
         ] = "sheet",
         algo_resolution: Optional[int] = None,
-        verbose: bool = True,
+        compute_density: bool = False,
         **kwargs,
     ) -> pv.PolyData:
         """
@@ -581,7 +582,7 @@ class Tpms(BasicGeometry):
             )
         polydata = getattr(self, f"vtk_{type_part.replace(' ', '_')}")()
         polydata = polydata.clean().triangulate()
-        if verbose:
+        if compute_density:
             density = polydata.volume / self.grid.volume
             logging.info("TPMS density = %g%%", round(density * 100, 2))
 

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -111,7 +111,7 @@ class Tpms(BasicGeometry):
         cls,
         surface_function: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray],
         part_type: Literal["sheet", "lower skeletal", "upper skeletal"],
-        density: float = 0.3,
+        density: float,
         resolution: int = 20,
     ) -> float:
         """

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -162,7 +162,7 @@ class Tpms(BasicGeometry):
 
         def density(offset: float) -> float:
             temp_tpms._update_offset(offset)
-            return polydata_func().volume
+            return abs(polydata_func().volume)
 
         computed_offset = root_scalar(
             lambda offset: density(offset) - self.density,
@@ -494,7 +494,6 @@ class Tpms(BasicGeometry):
         smoothing: int = 0,
         verbose: bool = True,
         algo_resolution: Optional[int] = None,
-        compute_density: bool = False,
         **kwargs,
     ) -> cq.Shape:
         """
@@ -535,12 +534,6 @@ class Tpms(BasicGeometry):
 
         shape = self._extract_part_from_box(type_part, eps, smoothing, verbose)
 
-        if compute_density:
-            density = shape.Volume() / (
-                np.prod(self.repeat_cell) * np.prod(self.cell_size)
-            )
-            logging.info("TPMS density = %g%%", round(density * 100, 2))
-
         shape = rotateEuler(
             obj=shape,
             center=(0, 0, 0),
@@ -556,7 +549,6 @@ class Tpms(BasicGeometry):
             "sheet", "lower skeletal", "upper skeletal", "surface"
         ] = "sheet",
         algo_resolution: Optional[int] = None,
-        compute_density: bool = False,
         **kwargs,
     ) -> pv.PolyData:
         """
@@ -580,9 +572,6 @@ class Tpms(BasicGeometry):
             )
         polydata = getattr(self, f"vtk_{type_part.replace(' ', '_')}")()
         polydata = polydata.clean().triangulate()
-        if compute_density:
-            density = polydata.volume / self.grid.volume
-            logging.info("TPMS density = %g%%", round(density * 100, 2))
 
         polydata = rotatePvEuler(
             polydata,

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -106,26 +106,12 @@ class Tpms(BasicGeometry):
             raise ValueError("density must be between 0 and 1")
         self.density = density
 
-    def _max_density(
-        self,
-        part_type: Literal["sheet", "lower skeletal", "upper skeletal"],
-        resolution: Optional[int] = None,
-    ) -> float:
-        if part_type == "sheet":
-            return 1.0
-        tpms = Tpms(
-            surface_function=self.surface_function,
-            offset=0.0,
-            resolution=resolution if resolution is not None else self.resolution,
-        )
-        return tpms.generateVtk(type_part=part_type).volume / tpms.grid.volume
-
     @classmethod
     def offset_from_density(
         cls,
         surface_function: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray],
         part_type: Literal["sheet", "lower skeletal", "upper skeletal"],
-        density: float | Literal["max"] = "max",
+        density: float = 0.3,
         resolution: int = 20,
     ) -> float:
         """
@@ -139,14 +125,6 @@ class Tpms(BasicGeometry):
 
         :return: corresponding offset value
         """
-        if not isinstance(density, (int, float)) and density != "max":
-            raise ValueError("density must be a float between 0 and 1 or 'max'")
-        if density == "max":
-            if part_type == "sheet":
-                tpms = Tpms(surface_function=surface_function, resolution=resolution)
-                return 2.0 * np.max(tpms.grid["surface"])
-            return 0.0  # skeletal
-
         tpms = Tpms(surface_function=surface_function, density=density)
         tpms._compute_offset_to_fit_density(part_type=part_type, resolution=resolution)
 
@@ -165,19 +143,21 @@ class Tpms(BasicGeometry):
             surface_function=self.surface_function,
             resolution=resolution if resolution is not None else self.resolution,
         )
-        max_density = temp_tpms._max_density(part_type=part_type, resolution=resolution)
-        if self.density > max_density:
-            raise ValueError(
-                f"density ({self.density}) must be lower than {max_density} for \
-                    the {part_type} part of the given TPMS function"
-            )
 
-        if self.density == max_density:
-            offset = 2.0 * np.max(self.grid["surface"]) if part_type == "sheet" else 0.0
+        min_field = np.min(self.grid["surface"])
+        max_field = np.max(self.grid["surface"])
+        if part_type == "sheet":
+            min_offset = 0.0
+            max_offset = 2.0 * max(abs(min_field), max_field)
+        else:
+            min_offset = 2.0 * min_field
+            max_offset = 2.0 * max_field
+
+        if self.density == 1.0:
+            offset = max_offset if part_type == "sheet" else min_offset
             self._update_offset(offset)
             return
 
-        bound = 2.0 * np.max(self.grid["surface"])
         grid_volume = temp_tpms.grid.volume
 
         polydata_func = getattr(temp_tpms, f"vtk_{part_type.replace(' ', '_')}")
@@ -188,7 +168,7 @@ class Tpms(BasicGeometry):
 
         computed_offset = root_scalar(
             lambda offset: density(offset) - self.density,
-            bracket=[-bound, bound],
+            bracket=[min_offset, max_offset],
         ).root
         self._update_offset(computed_offset)
         logging.info("computed offset = %.3f", computed_offset)
@@ -556,8 +536,11 @@ class Tpms(BasicGeometry):
 
         shape = self._extract_part_from_box(type_part, eps, smoothing, verbose)
 
-        density = shape.Volume() / (np.prod(self.repeat_cell) * np.prod(self.cell_size))
-        logging.info("TPMS density = %d%%", round(density * 100, 2))
+        if verbose:
+            density = shape.Volume() / (
+                np.prod(self.repeat_cell) * np.prod(self.cell_size)
+            )
+            logging.info("TPMS density = %g%%", round(density * 100, 2))
 
         shape = rotateEuler(
             obj=shape,
@@ -574,6 +557,7 @@ class Tpms(BasicGeometry):
             "sheet", "lower skeletal", "upper skeletal", "surface"
         ] = "sheet",
         algo_resolution: Optional[int] = None,
+        verbose: bool = True,
         **kwargs,
     ) -> pv.PolyData:
         """
@@ -597,8 +581,9 @@ class Tpms(BasicGeometry):
             )
         polydata = getattr(self, f"vtk_{type_part.replace(' ', '_')}")()
         polydata = polydata.clean().triangulate()
-        density = polydata.volume / self.grid.volume
-        logging.info("TPMS density = %d%%", round(density * 100, 2))
+        if verbose:
+            density = polydata.volume / self.grid.volume
+            logging.info("TPMS density = %g%%", round(density * 100, 2))
 
         polydata = rotatePvEuler(
             polydata,

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -302,7 +302,7 @@ def test_tpms_given_100_percent_density_must_return_a_cube(
     )
 
 
-def test_tpms_given_density_must_return_corresponding_offset():
+def test_tpms_offset_from_density_given_density_must_return_valid_offset():
     """Test for the volume of the TPMS shapes generated with CadQuery and VTK."""
     tpms = microgen.Tpms(
         surface_function=microgen.surface_functions.gyroid,

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -313,7 +313,8 @@ def test_tpms_given_density_must_return_corresponding_offset():
         density=0.5,
         part_type="sheet",
     )
-    assert 0 < offset < -2.0 * np.min(tpms.grid["surface"])
+    max_offset = -2.0 * np.min(tpms.grid["surface"])
+    assert 0 < offset < max_offset
 
 
 def test_tpms_given_property_must_return_the_same_value():


### PR DESCRIPTION
This PR fixes a bug where the bounds used to compute the TPMS offset from the given density were not chosen the right way.

It also removes the "max" option in the density value since it is now possible to generate skeletal parts with negative offset.
Now it is possible to generate sheets, lower and upper skeletals in a density range of `]0; 1]`

The corresponding tests have been updated.