### PR TITLE
correct bug in box_mesh.py

### DIFF
--- a/microgen/box_mesh.py
+++ b/microgen/box_mesh.py
@@ -661,12 +661,12 @@ class BoxMesh(SingleMesh):
             np.array([rve.center[0], rve.center[1], rve.z_max]),
         ]
         size_planes = [
-            2.0 * rve.dx,
-            2.0 * rve.dx,
-            2.0 * rve.dy,
-            2.0 * rve.dy,
-            2.0 * rve.dz,
-            2.0 * rve.dz,
+            2.0 * np.max([rve.dim[1], rve.dim[2]]),
+            2.0 * np.max([rve.dim[1], rve.dim[1]]),
+            2.0 * np.max([rve.dim[0], rve.dim[2]]),
+            2.0 * np.max([rve.dim[0], rve.dim[2]]),
+            2.0 * np.max([rve.dim[0], rve.dim[1]]),
+            2.0 * np.max([rve.dim[0], rve.dim[1]]),
         ]
 
         surface = self.surface

--- a/microgen/box_mesh.py
+++ b/microgen/box_mesh.py
@@ -662,7 +662,7 @@ class BoxMesh(SingleMesh):
         ]
         size_planes = [
             2.0 * np.max([rve.dim[1], rve.dim[2]]),
-            2.0 * np.max([rve.dim[1], rve.dim[1]]),
+            2.0 * np.max([rve.dim[1], rve.dim[2]]),
             2.0 * np.max([rve.dim[0], rve.dim[2]]),
             2.0 * np.max([rve.dim[0], rve.dim[2]]),
             2.0 * np.max([rve.dim[0], rve.dim[1]]),

--- a/tests/test_box_mesh.py
+++ b/tests/test_box_mesh.py
@@ -106,33 +106,37 @@ def _box_mesh_elements() -> Dict[pv.CellType, npt.NDArray[np.int_]]:
 @pytest.fixture(scope="function")
 def default_box_mesh() -> Tuple[BoxMesh, Rve]:
     mesh = BoxMesh(_box_mesh_points(), _box_mesh_elements())
-    rve = Rve(dim=(1,1,1), center=(0.5, 0.5, 0.5))    
+    rve = Rve(dim=(1, 1, 1), center=(0.5, 0.5, 0.5))
     return (mesh, rve)
+
 
 @pytest.fixture(scope="function")
 def expanded_box_mesh_x() -> Tuple[BoxMesh, Rve]:
-    expanded_mesh = _box_mesh_points() 
-    expanded_mesh[:, 0] *= 3.    
+    expanded_mesh = _box_mesh_points()
+    expanded_mesh[:, 0] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
-    rve = Rve(dim=(3,1,1), center=(1.5, 0.5, 0.5))
+    rve = Rve(dim=(3, 1, 1), center=(1.5, 0.5, 0.5))
     return (mesh, rve)
+
 
 @pytest.fixture(scope="function")
 def expanded_box_mesh_y() -> Tuple[BoxMesh, Rve]:
-    expanded_mesh = _box_mesh_points() 
-    expanded_mesh[:, 1] *= 3.    
+    expanded_mesh = _box_mesh_points()
+    expanded_mesh[:, 1] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
-    rve = Rve(dim=(1,3,1), center=(0.5, 1.5, 0.5))
+    rve = Rve(dim=(1, 3, 1), center=(0.5, 1.5, 0.5))
     return (mesh, rve)
+
 
 @pytest.fixture(scope="function")
 def expanded_box_mesh_z() -> Tuple[BoxMesh, Rve]:
-    expanded_mesh = _box_mesh_points() 
-    expanded_mesh[:, 2] *= 3.    
+    expanded_mesh = _box_mesh_points()
+    expanded_mesh[:, 2] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
-    rve = Rve(dim=(1,1,3), center=(0.5, 0.5, 1.5))
+    rve = Rve(dim=(1, 1, 3), center=(0.5, 0.5, 1.5))
     print(expanded_mesh)
     return (mesh, rve)
+
 
 def _check_triangle_on_boundary(
     surface_mesh: pv.PolyData, triangle_index: int, rve: Rve
@@ -153,19 +157,19 @@ def _check_triangle_on_boundary(
                 return True
     return False
 
+
 @pytest.mark.parametrize(
     "box_mesh",
     [
         "default_box_mesh",
         "expanded_box_mesh_x",
         "expanded_box_mesh_y",
-        "expanded_box_mesh_z",                
+        "expanded_box_mesh_z",
     ],
 )
 def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets(
     box_mesh: BoxMesh, request
 ) -> None:
-
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     target_center: npt.NDArray[np.float_] = rve.center
     target_corners: List[int] = [0, 2, 6, 8, 18, 20, 24, 26]
@@ -190,10 +194,12 @@ def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets
         "default_box_mesh",
         "expanded_box_mesh_x",
         "expanded_box_mesh_y",
-        "expanded_box_mesh_z",                
+        "expanded_box_mesh_z",
     ],
 )
-def test_given_box_mesh_rve_property_must_build_correct_rve(box_mesh : BoxMesh, request) -> None:
+def test_given_box_mesh_rve_property_must_build_correct_rve(
+    box_mesh: BoxMesh, request
+) -> None:
     box_mesh_to_test, target_rve = request.getfixturevalue(box_mesh)
     test_rve = box_mesh_to_test.rve
 
@@ -201,23 +207,24 @@ def test_given_box_mesh_rve_property_must_build_correct_rve(box_mesh : BoxMesh, 
         test_rve.dim == target_rve.dim
     )
 
+
 @pytest.mark.parametrize(
     "box_mesh",
     [
         "default_box_mesh",
         "expanded_box_mesh_x",
         "expanded_box_mesh_y",
-        "expanded_box_mesh_z",                
+        "expanded_box_mesh_z",
     ],
 )
 def test_given_box_box_mesh_boundary_elements_must_find_boundary_surface_elements(
-    box_mesh : BoxMesh, request
+    box_mesh: BoxMesh, request
 ) -> None:
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     expected_number_of_cells = 48
     boundary, boundary_cells_index = box_mesh_to_test.boundary_elements(rve)
     print(boundary)
-    print(boundary_cells_index)    
+    print(boundary_cells_index)
     bool_check_triangle_on_boundary_list = []
     for triangle_index in boundary_cells_index:
         bool_check_triangle_on_boundary_list.append(

--- a/tests/test_box_mesh.py
+++ b/tests/test_box_mesh.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 import pyvista as pv
+from pytest import FixtureRequest
 
 from microgen import BoxMesh, Rve
 
@@ -168,7 +169,7 @@ def _check_triangle_on_boundary(
     ],
 )
 def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets(
-    box_mesh: BoxMesh, request
+    box_mesh: BoxMesh, request: FixtureRequest
 ) -> None:
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     target_center: npt.NDArray[np.float_] = rve.center
@@ -198,7 +199,7 @@ def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets
     ],
 )
 def test_given_box_mesh_rve_property_must_build_correct_rve(
-    box_mesh: BoxMesh, request
+    box_mesh: BoxMesh, request: FixtureRequest
 ) -> None:
     box_mesh_to_test, target_rve = request.getfixturevalue(box_mesh)
     test_rve = box_mesh_to_test.rve
@@ -218,7 +219,7 @@ def test_given_box_mesh_rve_property_must_build_correct_rve(
     ],
 )
 def test_given_box_box_mesh_boundary_elements_must_find_boundary_surface_elements(
-    box_mesh: BoxMesh, request
+    box_mesh: BoxMesh, request: FixtureRequest
 ) -> None:
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     expected_number_of_cells = 48

--- a/tests/test_box_mesh.py
+++ b/tests/test_box_mesh.py
@@ -135,7 +135,6 @@ def expanded_box_mesh_z() -> Tuple[BoxMesh, Rve]:
     expanded_mesh[:, 2] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
     rve = Rve(dim=(1, 1, 3), center=(0.5, 0.5, 1.5))
-    print(expanded_mesh)
     return (mesh, rve)
 
 
@@ -224,8 +223,6 @@ def test_given_box_box_mesh_boundary_elements_must_find_boundary_surface_element
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     expected_number_of_cells = 48
     boundary, boundary_cells_index = box_mesh_to_test.boundary_elements(rve)
-    print(boundary)
-    print(boundary_cells_index)
     bool_check_triangle_on_boundary_list = []
     for triangle_index in boundary_cells_index:
         bool_check_triangle_on_boundary_list.append(

--- a/tests/test_box_mesh.py
+++ b/tests/test_box_mesh.py
@@ -1,5 +1,5 @@
 import math as m
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -103,16 +103,36 @@ def _box_mesh_elements() -> Dict[pv.CellType, npt.NDArray[np.int_]]:
     return elements_dict
 
 
-@pytest.fixture(name="default_box_mesh", scope="function")
-def fixture_default_box_mesh() -> BoxMesh:
+@pytest.fixture(scope="function")
+def default_box_mesh() -> Tuple[BoxMesh, Rve]:
     mesh = BoxMesh(_box_mesh_points(), _box_mesh_elements())
+    rve = Rve(dim=(1,1,1), center=(0.5, 0.5, 0.5))    
+    return (mesh, rve)
 
-    return mesh
+@pytest.fixture(scope="function")
+def expanded_box_mesh_x() -> Tuple[BoxMesh, Rve]:
+    expanded_mesh = _box_mesh_points() 
+    expanded_mesh[:, 0] *= 3.    
+    mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
+    rve = Rve(dim=(3,1,1), center=(1.5, 0.5, 0.5))
+    return (mesh, rve)
 
+@pytest.fixture(scope="function")
+def expanded_box_mesh_y() -> Tuple[BoxMesh, Rve]:
+    expanded_mesh = _box_mesh_points() 
+    expanded_mesh[:, 1] *= 3.    
+    mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
+    rve = Rve(dim=(1,3,1), center=(0.5, 1.5, 0.5))
+    return (mesh, rve)
 
-def _default_rve() -> Rve:
-    return Rve(center=(0.5, 0.5, 0.5))
-
+@pytest.fixture(scope="function")
+def expanded_box_mesh_z() -> Tuple[BoxMesh, Rve]:
+    expanded_mesh = _box_mesh_points() 
+    expanded_mesh[:, 2] *= 3.    
+    mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
+    rve = Rve(dim=(1,1,3), center=(0.5, 0.5, 1.5))
+    print(expanded_mesh)
+    return (mesh, rve)
 
 def _check_triangle_on_boundary(
     surface_mesh: pv.PolyData, triangle_index: int, rve: Rve
@@ -133,42 +153,71 @@ def _check_triangle_on_boundary(
                 return True
     return False
 
-
-def test_given_box_mesh__construct_must_find_center_corners_edges_faces_node_sets(
-    default_box_mesh,
+@pytest.mark.parametrize(
+    "box_mesh",
+    [
+        "default_box_mesh",
+        "expanded_box_mesh_x",
+        "expanded_box_mesh_y",
+        "expanded_box_mesh_z",                
+    ],
+)
+def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets(
+    box_mesh: BoxMesh, request
 ) -> None:
-    target_center: npt.NDArray[np.float_] = np.array([0.5, 0.5, 0.5])
+
+    box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
+    target_center: npt.NDArray[np.float_] = rve.center
     target_corners: List[int] = [0, 2, 6, 8, 18, 20, 24, 26]
     target_edges: List[int] = [1, 3, 5, 7, 9, 11, 15, 17, 19, 21, 23, 25]
     target_faces: List[int] = [4, 10, 12, 14, 16, 22]
 
-    box_mesh_corners = sorted(np.concatenate(list(default_box_mesh.corners.values())))
-    box_mesh_edges = sorted(np.concatenate(list(default_box_mesh.edges.values())))
-    box_mesh_faces = sorted(np.concatenate(list(default_box_mesh.faces.values())))
+    box_mesh_corners = sorted(np.concatenate(list(box_mesh_to_test.corners.values())))
+    box_mesh_edges = sorted(np.concatenate(list(box_mesh_to_test.edges.values())))
+    box_mesh_faces = sorted(np.concatenate(list(box_mesh_to_test.faces.values())))
 
     assert (
-        (default_box_mesh.center == target_center).all()
+        (box_mesh_to_test.center == target_center).all()
         and box_mesh_corners == target_corners
         and box_mesh_edges == target_edges
         and box_mesh_faces == target_faces
     )
 
 
-def test_given_box_mesh_rve_property_must_build_correct_rve(default_box_mesh) -> None:
-    target_rve = _default_rve()
-    test_rve = default_box_mesh.rve
+@pytest.mark.parametrize(
+    "box_mesh",
+    [
+        "default_box_mesh",
+        "expanded_box_mesh_x",
+        "expanded_box_mesh_y",
+        "expanded_box_mesh_z",                
+    ],
+)
+def test_given_box_mesh_rve_property_must_build_correct_rve(box_mesh : BoxMesh, request) -> None:
+    box_mesh_to_test, target_rve = request.getfixturevalue(box_mesh)
+    test_rve = box_mesh_to_test.rve
 
     assert np.all(test_rve.center == target_rve.center) and np.all(
         test_rve.dim == target_rve.dim
     )
 
-
+@pytest.mark.parametrize(
+    "box_mesh",
+    [
+        "default_box_mesh",
+        "expanded_box_mesh_x",
+        "expanded_box_mesh_y",
+        "expanded_box_mesh_z",                
+    ],
+)
 def test_given_box_box_mesh_boundary_elements_must_find_boundary_surface_elements(
-    default_box_mesh,
+    box_mesh : BoxMesh, request
 ) -> None:
+    box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     expected_number_of_cells = 48
-    rve = _default_rve()
-    boundary, boundary_cells_index = default_box_mesh.boundary_elements(rve)
+    boundary, boundary_cells_index = box_mesh_to_test.boundary_elements(rve)
+    print(boundary)
+    print(boundary_cells_index)    
     bool_check_triangle_on_boundary_list = []
     for triangle_index in boundary_cells_index:
         bool_check_triangle_on_boundary_list.append(

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -69,7 +69,7 @@ def _generate_cqcompound_octettruss(rve: Rve):
     radius = np.full_like(xc, 0.05)
 
     listPhases: List[Phase] = []
-    listPeriodicPhases: List[Phase] = []
+    list_periodic_phases: List[Phase] = []
     n = len(xc)
 
     for i in range(0, n):
@@ -84,9 +84,9 @@ def _generate_cqcompound_octettruss(rve: Rve):
 
     for phase_elem in listPhases:
         periodicPhase = periodic(phase=phase_elem, rve=rve)
-        listPeriodicPhases.append(periodicPhase)
+        list_periodic_phases.append(periodicPhase)
 
-    return listPeriodicPhases
+    return list_periodic_phases
 
 
 @pytest.fixture(scope="function")
@@ -103,7 +103,9 @@ def box_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
 
 
 @pytest.fixture(scope="function")
-def box_homogeneous_double(rve_double: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
+def box_homogeneous_double(
+    rve_double: Rve,
+) -> Tuple[cq.Shape, List[Phase], Rve]:
     shape = Box(
         center=rve_double.center,
         orientation=(0.0, 0.0, 0.0),
@@ -131,10 +133,12 @@ def box_homogeneous_double_centered(
 
 
 @pytest.fixture(scope="function")
-def octet_truss_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
-    listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
+def octet_truss_homogeneous_unit(
+    rve_unit: Rve,
+) -> Tuple[cq.Shape, List[Phase], Rve]:
+    list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
     merged = fuseShapes(
-        [phase.shape for phase in listPeriodicPhases], retain_edges=False
+        [phase.shape for phase in list_periodic_phases], retain_edges=False
     )
     listcqphases = [Phase(shape=merged)]
     return (merged, listcqphases, rve_unit)
@@ -144,18 +148,20 @@ def octet_truss_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], 
 def octet_truss_homogeneous_double_centered(
     rve_double_centered: Rve,
 ) -> Tuple[cq.Shape, List[Phase], Rve]:
-    listPeriodicPhases = _generate_cqcompound_octettruss(rve_double_centered)
+    list_periodic_phases = _generate_cqcompound_octettruss(rve_double_centered)
     merged = fuseShapes(
-        [phase.shape for phase in listPeriodicPhases], retain_edges=False
+        [phase.shape for phase in list_periodic_phases], retain_edges=False
     )
     listcqphases = [Phase(shape=merged)]
     return (merged, listcqphases, rve_double_centered)
 
 
 @pytest.fixture(scope="function")
-def octet_truss_heterogeneous(rve_unit: Rve) -> Tuple[cq.Compound, List[Phase], Rve]:
-    listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
-    listcqphases = cutPhases(phaseList=listPeriodicPhases, reverseOrder=False)
+def octet_truss_heterogeneous(
+    rve_unit: Rve,
+) -> Tuple[cq.Compound, List[Phase], Rve]:
+    list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
+    listcqphases = cutPhases(phaseList=list_periodic_phases, reverseOrder=False)
     return (
         cq.Compound.makeCompound([phase.shape for phase in listcqphases]),
         listcqphases,

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Tuple
 
 import cadquery as cq
 import numpy as np
@@ -90,7 +90,7 @@ def _generate_cqcompound_octettruss(rve: Rve):
 
 
 @pytest.fixture(scope="function")
-def box_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, List[Phase]):
+def box_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
     shape = Box(
         center=rve_unit.center,
         orientation=(0.0, 0.0, 0.0),
@@ -103,7 +103,7 @@ def box_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, List[Phase]):
 
 
 @pytest.fixture(scope="function")
-def box_homogeneous_double(rve_double: Rve) -> (cq.Shape, List[Phase]):
+def box_homogeneous_double(rve_double: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
     shape = Box(
         center=rve_double.center,
         orientation=(0.0, 0.0, 0.0),
@@ -118,7 +118,7 @@ def box_homogeneous_double(rve_double: Rve) -> (cq.Shape, List[Phase]):
 @pytest.fixture(scope="function")
 def box_homogeneous_double_centered(
     rve_double_centered: Rve,
-) -> (cq.Shape, List[Phase]):
+) -> (cq.Shape, List[Phase], Rve):
     shape = Box(
         center=rve_double_centered.center,
         orientation=(0.0, 0.0, 0.0),
@@ -131,7 +131,7 @@ def box_homogeneous_double_centered(
 
 
 @pytest.fixture(scope="function")
-def octet_truss_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, List[Phase]):
+def octet_truss_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
     listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
     merged = fuseShapes(
         [phase.shape for phase in listPeriodicPhases], retain_edges=False
@@ -143,7 +143,7 @@ def octet_truss_homogeneous_unit(rve_unit: Rve) -> (cq.Shape, List[Phase]):
 @pytest.fixture(scope="function")
 def octet_truss_homogeneous_double_centered(
     rve_double_centered: Rve,
-) -> (cq.Shape, List[Phase]):
+) -> Tuple[cq.Shape, List[Phase], Rve]:
     listPeriodicPhases = _generate_cqcompound_octettruss(rve_double_centered)
     merged = fuseShapes(
         [phase.shape for phase in listPeriodicPhases], retain_edges=False
@@ -153,7 +153,7 @@ def octet_truss_homogeneous_double_centered(
 
 
 @pytest.fixture(scope="function")
-def octet_truss_heterogeneous(rve_unit: Rve) -> (cq.Compound, List[Phase]):
+def octet_truss_heterogeneous(rve_unit: Rve) -> Tuple[cq.Compound, List[Phase], Rve]:
     listPeriodicPhases = _generate_cqcompound_octettruss(rve_unit)
     listcqphases = cutPhases(phaseList=listPeriodicPhases, reverseOrder=False)
     return (
@@ -175,7 +175,7 @@ def octet_truss_heterogeneous(rve_unit: Rve) -> (cq.Compound, List[Phase]):
     ],
 )
 def test_octettruss_mesh_must_be_periodic(
-    shape: Union[cq.Compound, cq.Shape],
+    shape: tuple[Union[cq.Compound, cq.Shape], List[Phase], Rve],
     request,
     tmp_output_compound_filename: str,
     tmp_output_vtk_filename: str,

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
 import cadquery as cq
 import numpy as np

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -175,7 +175,7 @@ def octet_truss_heterogeneous(rve_unit: Rve) -> Tuple[cq.Compound, List[Phase], 
     ],
 )
 def test_octettruss_mesh_must_be_periodic(
-    shape: tuple[Union[cq.Compound, cq.Shape], List[Phase], Rve],
+    shape: Tuple[Union[cq.Compound, cq.Shape], List[Phase], Rve],
     request,
     tmp_output_compound_filename: str,
     tmp_output_vtk_filename: str,


### PR DESCRIPTION
This PR corrects a bug when the dimensions of the eve is not similar in all directions. If one of the dimension is more than 2 times another one, the boundary elements are not correctly captured.

@edit : also modified Type hint for Tuple in test of mesh periodic