### PR TITLE
Use mmg in integration CI on Linux

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,6 +43,13 @@ jobs:
           uv pip install --system microgen@. --no-deps
         shell: micromamba-shell {0}
 
+      - name: Examples on Linux and macOS with MMG
+        if: runner.os != 'Windows'
+        run: |
+          conda install -c set3mah mmg
+          python examples/run_examples.py -n auto
+        shell: micromamba-shell {0}
+
       - name: Install microgen for Windows
         if: runner.os == 'Windows'
         run: |
@@ -50,19 +57,7 @@ jobs:
           uv pip install --system microgen@. --no-deps
         shell: pwsh
 
-      - name: Examples on Linux
-        if: runner.os == 'Linux'
-        run: python examples/run_examples.py --no-mmg -n auto
-        shell: micromamba-shell {0}
-
-      - name: Examples on macOS
-        if: runner.os == 'macOS'
-        run: |
-          conda install -c set3mah mmg
-          python examples/run_examples.py -n auto
-        shell: micromamba-shell {0}
-
-      - name: Examples on Windows
+      - name: Examples on Windows without MMG
         if: runner.os == 'Windows'
         run: python examples/run_examples.py --no-mmg -n auto
         shell: pwsh


### PR DESCRIPTION
This PR aims to use MMG (5.6.0) in the CI for integration tests on Linux.