### PR TITLE
Update MacOS CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install
         run: |
           pip install --upgrade pip 
-          pip install uv
-          uv pip install --system microgen@. pytest pytest-xdist
+          # pip install uv
+          pip install --system microgen@. pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           pip install --upgrade pip
           # pip install uv
           # uv pip install --system microgen@. pytest pytest-xdist
-          pip install . pytest pytest-xdist cadquery-ocp
+          pip install . pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,10 +32,10 @@ jobs:
 
       - name: Install
         run: |
-          pip install --upgrade pip 
+          pip install --upgrade pip
           # pip install uv
           # uv pip install --system microgen@. pytest pytest-xdist
-          pip install . pytest pytest-xdist
+          pip install . pytest pytest-xdist cadquery-ocp
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.8", "3.11"]
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -31,6 +32,7 @@ jobs:
 
       - name: Install
         run: |
+          pip install --upgrade pip 
           pip install uv
           uv pip install --system microgen@. pytest pytest-xdist
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-14", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.8", "3.11"]
 
     steps:
@@ -33,9 +33,9 @@ jobs:
       - name: Install
         run: |
           pip install --upgrade pip
-          # pip install uv
-          # uv pip install --system microgen@. pytest pytest-xdist
-          pip install . pytest pytest-xdist
+          pip install uv
+          uv pip install --system microgen@. pytest pytest-xdist
+          # pip install . pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,10 +32,8 @@ jobs:
 
       - name: Install
         run: |
-          pip install --upgrade pip
           pip install uv
           uv pip install --system microgen@. pytest pytest-xdist
-          # pip install . pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           pip install --upgrade pip 
           # pip install uv
-          pip install microgen@. pytest pytest-xdist
+          # uv pip install --system microgen@. pytest pytest-xdist
+          pip install . pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           pip install --upgrade pip 
           # pip install uv
-          pip install --system microgen@. pytest pytest-xdist
+          pip install microgen@. pytest pytest-xdist
 
       - name: Test
         run: pytest tests --numprocesses=auto

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,10 @@ jobs:
           micromamba-version: "1.5.7-0" # any version from https://github.com/mamba-org/micromamba-releases
           # environment-file: environment.yml
           environment-name: microgen
-          create-args: python=${{ matrix.python-version }} pyvista scipy python-gmsh meshio occt cadquery
+          condarc: |
+            channels:
+              - set3mah
+          create-args: python=${{ matrix.python-version }} pyvista scipy python-gmsh meshio occt cadquery mmg
           init-shell: powershell bash
           download-micromamba: true
           cache-environment: false
@@ -45,9 +48,7 @@ jobs:
 
       - name: Examples on Linux and macOS with MMG
         if: runner.os != 'Windows'
-        run: |
-          mamba install -c set3mah mmg
-          python examples/run_examples.py -n auto
+        run: python examples/run_examples.py -n auto
         shell: micromamba-shell {0}
 
       - name: Install microgen for Windows

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.9", "3.11"]
 
     steps:
@@ -24,13 +24,13 @@ jobs:
         with:
           generate-run-shell: true
           micromamba-version: "1.5.7-0" # any version from https://github.com/mamba-org/micromamba-releases
-          # environment-file: environment.yml
-          environment-name: microgen
-          condarc: |
-            channels:
-              - set3mah
-              - conda-forge
-          create-args: python=${{ matrix.python-version }} pyvista scipy python-gmsh meshio occt cadquery mmg
+          environment-file: environment.yml
+          # environment-name: microgen
+          # condarc: |
+          #   channels:
+          #     - set3mah
+          #     - conda-forge
+          create-args: python=${{ matrix.python-version }} # pyvista scipy python-gmsh meshio occt cadquery mmg
           init-shell: powershell bash
           download-micromamba: true
           cache-environment: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Examples on Linux and macOS with MMG
         if: runner.os != 'Windows'
         run: |
-          conda install -c set3mah mmg
+          mamba install -c set3mah mmg
           python examples/run_examples.py -n auto
         shell: micromamba-shell {0}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.9", "3.11"]
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,14 +23,9 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           generate-run-shell: true
-          micromamba-version: "1.5.7-0" # any version from https://github.com/mamba-org/micromamba-releases
+          micromamba-version: "1.5.8-0" # any version from https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
-          # environment-name: microgen
-          # condarc: |
-          #   channels:
-          #     - set3mah
-          #     - conda-forge
-          create-args: python=${{ matrix.python-version }} # pyvista scipy python-gmsh meshio occt cadquery mmg
+          create-args: python=${{ matrix.python-version }}
           init-shell: powershell bash
           download-micromamba: true
           cache-environment: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,7 @@ jobs:
           condarc: |
             channels:
               - set3mah
+              - conda-forge
           create-args: python=${{ matrix.python-version }} pyvista scipy python-gmsh meshio occt cadquery mmg
           init-shell: powershell bash
           download-micromamba: true

--- a/.github/workflows/mmg-packaging.yml
+++ b/.github/workflows/mmg-packaging.yml
@@ -24,7 +24,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: "macos-latest"
+    runs-on: "macos-13"
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/neper-packaging.yml
+++ b/.github/workflows/neper-packaging.yml
@@ -24,7 +24,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: "macos-latest"
+    runs-on: "macos-13"
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test-conda-package.yml
+++ b/.github/workflows/test-conda-package.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-13"]
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - scipy
   - python-gmsh
   - meshio
-  # - occt
   - cadquery
-  # - mmg
+  - mmg
 #  - neper


### PR DESCRIPTION
The `macos-latest` label now points to `macos-14`. For now, it seems not possible to install microgen in `macos-14` because of cadquery 2.3.

For this reason, the CI is updated to run temporarily on `macos-13`.