### PR TITLE
Fix infill issues

### DIFF
--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -912,7 +912,7 @@ class Infill(Tpms):
         self.obj = obj
         bounds = np.array(obj.bounds)
 
-        margin_factor = 1.0  # 001  # to avoid the object surface that can create issues
+        margin_factor = 1.001  # to avoid the object surface that can create issues
         obj_dim = margin_factor * (bounds[1::2] - bounds[::2])  # [dim_x, dim_y, dim_z]
 
         if cell_size is not None and repeat_cell is not None:

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from inspect import getmembers, isfunction
 from typing import Literal
 
-import microgen
 import numpy as np
 import numpy.typing as npt
 import pytest
+
+import microgen
 
 TEST_DEFAULT_OFFSET = 0.5
 
@@ -585,12 +586,22 @@ def test_infill_cylinder_has_expected_volume() -> None:
         density=density,
         repeat_cell=2,
     )
+    assert np.isclose(infill.sheet.volume, density * cylinder.volume, rtol=1e-2)
+
+
+def test_infill_cylinder_returns_single_connected_component_mesh() -> None:
+    """Test if the infilled cylinder returns a single connected component mesh."""
+    infill = microgen.Infill(
+        obj=microgen.Cylinder().generate_vtk(),
+        surface_function=microgen.surface_functions.gyroid,
+        offset=TEST_DEFAULT_OFFSET,
+        repeat_cell=2,
+    )
 
     components = infill.sheet.connectivity().point_data["RegionId"]
     n_unique = len(np.unique(components))
 
     assert n_unique == 1
-    assert np.isclose(infill.sheet.volume, density * cylinder.volume, rtol=1e-2)
 
 
 def test_infill_given_repeat_cell_and_cell_size_must_raise_an_error() -> None:

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -551,7 +551,7 @@ def test_infill_given_repeat_cell_must_use_corresponding_cell_size() -> None:
     )
 
     expected_cell_size = (1.0, 1.0, 0.5)
-    assert np.allclose(tpms.cell_size, expected_cell_size)
+    assert np.allclose(tpms.cell_size, expected_cell_size, rtol=1e-2)
 
 
 @pytest.mark.parametrize("kwarg", [{"cell_size": 0.5}, {"repeat_cell": 2}])
@@ -575,26 +575,21 @@ def test_infill_bounds_match_obj_bounds(kwarg: dict[str, int | float]) -> None:
     assert np.all(grid_dim < obj_dim + tpms.cell_size)
 
 
-def test_infill_fills_the_object_with_any_normal_orientation() -> None:
-    """Test if the object is filled correctly with any normal orientation."""
-    mesh = microgen.Box(dim=(1.0, 1.0, 1.0)).generate_vtk()
-    first = microgen.Infill(
-        obj=mesh,
+def test_infill_cylinder_has_expected_volume() -> None:
+    """Test if an infilled cylinder has the expected volume."""
+    density = 0.5
+    cylinder = microgen.Cylinder().generate_vtk()
+    infill = microgen.Infill(
+        cylinder,
         surface_function=microgen.surface_functions.gyroid,
-        offset=TEST_DEFAULT_OFFSET,
-        cell_size=0.5,
-    )
-    mesh = mesh.triangulate()
-    mesh.flip_normals()
-    second = microgen.Infill(
-        obj=mesh,
-        surface_function=microgen.surface_functions.gyroid,
-        offset=TEST_DEFAULT_OFFSET,
-        cell_size=0.5,
+        density=density,
+        repeat_cell=2,
     )
 
-    assert np.allclose(first.sheet.volume, second.sheet.volume)
-    assert first.sheet.points.shape == second.sheet.points.shape
+    components = infill.sheet.connectivity().point_data["RegionId"]
+    n_unique = len(np.unique(components))
+
+    assert n_unique == 1
 
 
 def test_infill_given_repeat_cell_and_cell_size_must_raise_an_error() -> None:

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -590,6 +590,7 @@ def test_infill_cylinder_has_expected_volume() -> None:
     n_unique = len(np.unique(components))
 
     assert n_unique == 1
+    assert np.isclose(infill.sheet.volume, density * cylinder.volume, rtol=1e-2)
 
 
 def test_infill_given_repeat_cell_and_cell_size_must_raise_an_error() -> None:


### PR DESCRIPTION
This PR fixes two issues with the infill feature where generating an infill inside of a cylinder resulted in a weird mesh as it can be seen on the following figure.

The issues are:
- Normals are not well computed and it results in a weird cone shape cut in a cap of the cylinder
    - This PR removes the automatic normal computation, and the input mesh is now required to have normals oriented towards the outside
    - The corresponding test is then removed
- Some small parts of the grid are kept after the `clip_surface` because the structured grid dimensions are made to match to bounding box of the mesh
    - This PR adds a margin factor `1.001` so that the grid is a little bit bigger than the bounding box of the mesh

![image](https://github.com/3MAH/microgen/assets/22714778/d9355497-ff5a-4890-9d02-2d3898d42642)
