### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-13", "windows-latest"]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.12
+    - python >=3.9,<3.12
     - pip
   run:
-    - python >=3.8,<3.12
+    - python >=3.9,<3.12
     - numpy
     - vtk
     - pyvista

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -1,5 +1,7 @@
 """Test examples"""
 
+from __future__ import annotations
+
 import argparse
 import multiprocessing
 import os
@@ -7,7 +9,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 
 GREEN = "\033[32m"
 RED = "\033[31m"
@@ -16,10 +17,10 @@ BOLD = "\033[1m"
 UNDERLINE = "\033[4m"
 
 
-def get_example_paths(exclude_dirs: List[str]) -> List[str]:
+def get_example_paths(exclude_dirs: list[str]) -> list[str]:
     """Get all the example paths in the examples directory.
     Exclude the directories in exclude_dirs."""
-    paths: List[str] = []
+    paths: list[str] = []
     for root, _, files in os.walk(Path(__file__).parent):
         if root not in exclude_dirs:
             paths.extend(
@@ -30,7 +31,7 @@ def get_example_paths(exclude_dirs: List[str]) -> List[str]:
     return paths
 
 
-def dashed_line(string: Optional[str] = "", char: str = "-") -> str:
+def dashed_line(string: str | None = "", char: str = "-") -> str:
     """Create a dashed line with a string in the middle."""
     terminal_width = shutil.get_terminal_size().columns
     title = f" {string} " if string else ""
@@ -41,12 +42,12 @@ def dashed_line(string: Optional[str] = "", char: str = "-") -> str:
 
 
 def launch_test_examples(
-    exclude_dirs: List[str],
+    exclude_dirs: list[str],
     n_procs: int = 1,
-) -> Tuple[List[str], List[str]]:
+) -> tuple[list[str], list[str]]:
     """Launch all the examples and return the paths of the examples that failed."""
     examples = get_example_paths(exclude_dirs=exclude_dirs)
-    failed: List[str] = []
+    failed: list[str] = []
     if n_procs == 1:
         for i, example in enumerate(examples):
             print(dashed_line(f"[{i}/{len(examples)}] {example}"))
@@ -58,7 +59,7 @@ def launch_test_examples(
             print(dashed_line())
             print()
     elif n_procs > 1:
-        results: Dict[str, multiprocessing.pool.AsyncResult] = {}
+        results: dict[str, multiprocessing.pool.AsyncResult] = {}
         with multiprocessing.Pool(processes=n_procs) as pool:
             for example in examples:
                 cmd = [sys.executable, example]
@@ -80,7 +81,7 @@ def launch_test_examples(
     return examples, failed
 
 
-def display_results(examples: List[str], failed: List[str]):
+def display_results(examples: list[str], failed: list[str]):
     """Display the results of the test examples.
     Raise an error if there are failed examples."""
     print(dashed_line(f"{UNDERLINE}{BOLD}RESULTS{RESET}"))

--- a/microgen/box_mesh.py
+++ b/microgen/box_mesh.py
@@ -2,8 +2,10 @@
 Cubic mesh for FE
 """
 
+from __future__ import annotations
+
 import warnings
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -37,7 +39,7 @@ class ClosestCellsOnBoundaries(NamedTuple):
 
     cells_id: npt.NDArray[np.int_]
     intersection_point_coords: npt.NDArray[np.float_]
-    closest_opposing_cells_id: List[npt.NDArray[np.int_]]
+    closest_opposing_cells_id: list[npt.NDArray[np.int_]]
 
 
 class BoxMesh(SingleMesh):
@@ -51,8 +53,8 @@ class BoxMesh(SingleMesh):
     def __init__(
         self,
         nodes_coords: npt.NDArray[np.float_],
-        elements: Dict[pv.CellType, npt.NDArray[np.int_]],
-        nodes_indices: Optional[npt.NDArray[np.int_]] = None,
+        elements: dict[pv.CellType, npt.NDArray[np.int_]],
+        nodes_indices: npt.NDArray[np.int_] | None = None,
     ) -> None:
         super().__init__(
             nodes_coords=nodes_coords,
@@ -61,11 +63,11 @@ class BoxMesh(SingleMesh):
         )
 
         self.rve = self._build_rve()
-        self.center: Optional[npt.NDArray[np.float_]] = None
+        self.center: npt.NDArray[np.float_] | None = None
         self._construct()
 
     @staticmethod
-    def from_pyvista(pvmesh: Union[pv.PolyData, pv.UnstructuredGrid]):
+    def from_pyvista(pvmesh: pv.PolyData | pv.UnstructuredGrid):
         """Build a BoxMesh from a pyvista UnstructuredGrid or PolyData mesh (in this last case,
         the PolyData object is cast into an Unstructured Grid).
         Node and element data are not copied (by default a shallow copy is operated)

--- a/microgen/external.py
+++ b/microgen/external.py
@@ -10,7 +10,6 @@ Functions related to external software
 from __future__ import annotations
 
 import subprocess
-from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -19,7 +18,7 @@ from microgen.shape import Polyhedron
 
 class Neper:
     @staticmethod
-    def run(filename: str, nbCell: int, dimCube: Tuple[float, float, float]) -> None:
+    def run(filename: str, nbCell: int, dimCube: tuple[float, float, float]) -> None:
         """
         Runs neper command from the command line
 
@@ -56,7 +55,7 @@ class Neper:
         subprocess.run(command, check=True)
 
     @staticmethod
-    def generateVoronoiFromTessFile(filename: str) -> List[Polyhedron]:
+    def generateVoronoiFromTessFile(filename: str) -> list[Polyhedron]:
         """
         Generates list of Voronoi polyhedron shapes from a tessellation file generated with neper
         """
@@ -94,7 +93,7 @@ class Neper:
         return polyhedra
 
     @staticmethod
-    def tessParse(filename: str) -> Dict[str, dict]:
+    def tessParse(filename: str) -> dict[str, dict]:
         """
         Parses tessellation file (.tess) generated with neper.
         Following .tess structure from `neper's`_ documentation:
@@ -402,14 +401,14 @@ def parseNeper(filename: str) -> tuple:
     listeSommets = []
     listeSommetsOut = []
     for i in range(nbPolys):
-        voro: Dict[str, Dict | List] = {}
+        voro: dict[str, dict | list] = {}
         voro["original"] = seed[i]
         voro["faces"] = []
         listeSommetsPoly = []
         sommets = []
         for facePoly in polys[i][1:]:
             listeSommetsFace = []
-            dicVertices: Dict[str, List] = {}
+            dicVertices: dict[str, list] = {}
             dicVertices["vertices"] = []
             for segment in faces[facePoly - 1][1:]:
                 # Listes des sommets avec numérotation globale et faces associées
@@ -493,7 +492,7 @@ class MmgError(Exception):
 
 class Mmg:
     @staticmethod
-    def _run_mmg_command(cmd: List[str]):
+    def _run_mmg_command(cmd: list[str]):
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except (subprocess.CalledProcessError, FileNotFoundError) as error:

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -2,7 +2,9 @@
 Mesh using gmsh
 """
 
-from typing import Iterator, List, Tuple
+from __future__ import annotations
+
+from typing import Iterator
 
 import gmsh
 import numpy as np
@@ -22,7 +24,7 @@ class OutputMeshNotPeriodicError(Exception):
 
 def mesh(
     mesh_file: str,
-    listPhases: List[Phase],
+    listPhases: list[Phase],
     size: float,
     order: int,
     output_file: str = "Mesh.msh",
@@ -48,7 +50,7 @@ def mesh(
 def meshPeriodic(
     mesh_file: str,
     rve: Rve,
-    listPhases: List[Phase],
+    listPhases: list[Phase],
     size: float,
     order: int,
     output_file: str = "MeshPeriodic.msh",
@@ -162,8 +164,8 @@ def is_periodic(
     return True
 
 
-def _generate_list_tags(list_phases: List[Phase]) -> List[List[int]]:
-    list_tags: List[List[int]] = []
+def _generate_list_tags(list_phases: list[Phase]) -> list[list[int]]:
+    list_tags: list[list[int]] = []
     start: int = 1
     for phase in list_phases:
         stop = start + len(phase.solids)
@@ -172,14 +174,14 @@ def _generate_list_tags(list_phases: List[Phase]) -> List[List[int]]:
     return list_tags
 
 
-def _generate_list_dim_tags(list_phases: List[Phase]) -> List[Tuple[int, int]]:
+def _generate_list_dim_tags(list_phases: list[Phase]) -> list[tuple[int, int]]:
     nb_tags = sum(len(phase.solids) for phase in list_phases)
     return [(_DIM_COUNT, tag) for tag in range(1, nb_tags + 1)]
 
 
 def _initialize_mesh(
     mesh_file: str,
-    list_phases: List[Phase],
+    list_phases: list[Phase],
     order: int,
     msh_file_version: int = 4,
 ) -> None:
@@ -210,7 +212,7 @@ def _finalize_mesh(
     size: float,
     output_file: str = "Mesh.msh",
 ) -> None:
-    list_dim_tags: List[Tuple[int, int]] = gmsh.model.getEntities()
+    list_dim_tags: list[tuple[int, int]] = gmsh.model.getEntities()
     gmsh.model.mesh.setSize(dimTags=list_dim_tags, size=size)
     gmsh.model.mesh.generate(dim=_DIM_COUNT)
     gmsh.write(fileName=output_file)
@@ -240,8 +242,8 @@ def _set_periodic(rve: Rve) -> None:
 
 def _iter_bounding_boxes(
     minimum: _Point3D, maximum: _Point3D, eps: float
-) -> Iterator[Tuple[np.ndarray, int]]:
-    entities: List[Tuple[int, int]] = gmsh.model.getEntitiesInBoundingBox(
+) -> Iterator[tuple[np.ndarray, int]]:
+    entities: list[tuple[int, int]] = gmsh.model.getEntitiesInBoundingBox(
         *np.subtract(minimum, eps), *np.add(maximum, eps), dim=2
     )
 
@@ -264,7 +266,7 @@ def _get_max(rve: Rve) -> np.ndarray:  # To add as a property of Rve?
     return np.array([rve.x_max, rve.y_max, rve.z_max])
 
 
-def _iter_matching_bounding_boxes(rve: Rve, axis: int) -> Iterator[Tuple[int, int]]:
+def _iter_matching_bounding_boxes(rve: Rve, axis: int) -> Iterator[tuple[int, int]]:
     deltas = _get_deltas(rve)
     eps: float = 1.0e-3 * min(deltas)
     minimum = _get_min(rve)
@@ -287,7 +289,7 @@ def _iter_matching_bounding_boxes(rve: Rve, axis: int) -> Iterator[Tuple[int, in
 def _set_periodic_on_axis(rve: Rve, axis: int) -> None:
     translation_matrix = np.eye(_DIM_COUNT + 1)
     translation_matrix[axis, _DIM_COUNT] = rve.dim[axis]
-    translation: List[float] = list(translation_matrix.flatten())
+    translation: list[float] = list(translation_matrix.flatten())
 
     for tag_min, tag_max in _iter_matching_bounding_boxes(rve, axis):
         gmsh.model.mesh.setPeriodic(

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -4,7 +4,7 @@ Boolean operations
 
 from __future__ import annotations
 
-from typing import List, Sequence, Tuple
+from typing import Sequence
 
 import cadquery as cq
 import numpy as np
@@ -19,7 +19,7 @@ from .rve import Rve
 
 def _getRotationAxes(
     psi: float, theta: float, phi: float
-) -> List[Tuple[float, float, float]]:
+) -> list[tuple[float, float, float]]:
     """
     Retrieve the 3 Euler rotation axes
 
@@ -43,7 +43,7 @@ def _getRotationAxes(
 
 def rotateEuler(
     obj: cq.Shape | cq.Workplane,
-    center: np.ndarray | Tuple[float, float, float],
+    center: np.ndarray | tuple[float, float, float],
     psi: float,
     theta: float,
     phi: float,
@@ -94,7 +94,7 @@ def rotatePvEuler(
     return rotated_obj
 
 
-def rescale(shape: cq.Shape, scale: float | Tuple[float, float, float]) -> cq.Shape:
+def rescale(shape: cq.Shape, scale: float | tuple[float, float, float]) -> cq.Shape:
     """
     Rescale given object according to scale parameters [dim_x, dim_y, dim_z]
 
@@ -106,7 +106,7 @@ def rescale(shape: cq.Shape, scale: float | Tuple[float, float, float]) -> cq.Sh
     return Phase.rescaleShape(shape, scale)
 
 
-def fuseShapes(cqShapeList: List[cq.Shape], retain_edges: bool) -> cq.Shape:
+def fuseShapes(cqShapeList: list[cq.Shape], retain_edges: bool) -> cq.Shape:
     """
     Fuse all shapes in cqShapeList
 
@@ -133,7 +133,7 @@ def fuseShapes(cqShapeList: List[cq.Shape], retain_edges: bool) -> cq.Shape:
             return cq.Shape(occ_Solids)
 
 
-def cutPhasesByShape(phaseList: List[Phase], cut_obj: cq.Shape) -> List[Phase]:
+def cutPhasesByShape(phaseList: list[Phase], cut_obj: cq.Shape) -> list[Phase]:
     """
     Cuts list of phases by a given shape
 
@@ -142,7 +142,7 @@ def cutPhasesByShape(phaseList: List[Phase], cut_obj: cq.Shape) -> List[Phase]:
 
     :return phase_cut: final result
     """
-    phase_cut: List[Phase] = []
+    phase_cut: list[Phase] = []
 
     for phase in phaseList:
         cut = BRepAlgoAPI_Cut(phase.shape.wrapped, cut_obj.wrapped)
@@ -151,7 +151,7 @@ def cutPhasesByShape(phaseList: List[Phase], cut_obj: cq.Shape) -> List[Phase]:
     return phase_cut
 
 
-def cutPhaseByShapeList(phaseToCut: Phase, cqShapeList: List[cq.Shape]) -> Phase:
+def cutPhaseByShapeList(phaseToCut: Phase, cqShapeList: list[cq.Shape]) -> Phase:
     """
     Cuts a phase by a list of shapes
 
@@ -168,7 +168,7 @@ def cutPhaseByShapeList(phaseToCut: Phase, cqShapeList: List[cq.Shape]) -> Phase
     return Phase(shape=resultCut)
 
 
-def cutShapes(cqShapeList: List[cq.Shape], reverseOrder: bool = True) -> List[cq.Shape]:
+def cutShapes(cqShapeList: list[cq.Shape], reverseOrder: bool = True) -> list[cq.Shape]:
     """
     Cuts list of shapes in the given order (or reverse) and fuse them.
 
@@ -177,7 +177,7 @@ def cutShapes(cqShapeList: List[cq.Shape], reverseOrder: bool = True) -> List[cq
 
     :return cutted_shapes: list of CQ Shape
     """
-    cutted_shapes: List[cq.Shape] = []
+    cutted_shapes: list[cq.Shape] = []
     if reverseOrder:
         cqShapeList_inv = cqShapeList[::-1]
     else:
@@ -202,7 +202,7 @@ def cutShapes(cqShapeList: List[cq.Shape], reverseOrder: bool = True) -> List[cq
     return cutted_shapes
 
 
-def cutPhases(phaseList: List[Phase], reverseOrder: bool = True) -> List[Phase]:
+def cutPhases(phaseList: list[Phase], reverseOrder: bool = True) -> list[Phase]:
     """
     Cuts list of shapes in the given order (or reverse) and fuse them.
 
@@ -218,8 +218,8 @@ def cutPhases(phaseList: List[Phase], reverseOrder: bool = True) -> List[Phase]:
 
 
 def rasterPhase(
-    phase: Phase, rve: Rve, grid: List[int], phasePerRaster: bool = True
-) -> Phase | List[Phase]:
+    phase: Phase, rve: Rve, grid: list[int], phasePerRaster: bool = True
+) -> Phase | list[Phase]:
     """
     Rasters solids from phase according to the rve divided by the given grid
 
@@ -230,14 +230,14 @@ def rasterPhase(
 
     :return: Phase or list of Phases
     """
-    solids: List[cq.Solid] = phase.split_solids(rve, grid)
+    solids: list[cq.Solid] = phase.split_solids(rve, grid)
 
     if phasePerRaster:
         return Phase.generate_phase_per_raster(solids, rve, grid)
     return Phase(solids=solids)
 
 
-def repeat_shape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq.Shape:
+def repeat_shape(unit_geom: cq.Shape, rve: Rve, grid: tuple[int, int, int]) -> cq.Shape:
     """
     Repeats unit geometry in each direction according to the given grid
 
@@ -250,7 +250,7 @@ def repeat_shape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> c
     return Phase.repeat_shape(unit_geom, rve, grid)
 
 
-def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq.Shape:
+def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: tuple[int, int, int]) -> cq.Shape:
     """
     Repeats unit geometry in each direction according to the given grid
 
@@ -264,7 +264,7 @@ def repeatShape(unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]) -> cq
 
 
 def repeatPolyData(
-    mesh: pv.PolyData, rve: Rve, grid: Tuple[int, int, int]
+    mesh: pv.PolyData, rve: Rve, grid: tuple[int, int, int]
 ) -> pv.PolyData:
     """
     Repeats mesh in each direction according to the given grid

--- a/microgen/periodic.py
+++ b/microgen/periodic.py
@@ -3,7 +3,6 @@ Periodic function to cut a shape periodically according to a RVE
 """
 
 import warnings
-from typing import Dict, List
 
 import cadquery as cq
 
@@ -23,7 +22,7 @@ def periodic(phase: Phase, rve: Rve) -> Phase:
     """
 
     wk_plane = cq.Workplane().add(phase.solids)  # shape to cut
-    periodic_object: List[cq.Workplane] = []
+    periodic_object: list[cq.Workplane] = []
 
     faces = ["x-", "x+", "y-", "y+", "z-", "z+"]
 
@@ -63,10 +62,10 @@ def periodic(phase: Phase, rve: Rve) -> Phase:
         "z+": (0, 0, -rve.dim[2]),
     }
 
-    intersected_faces: List[str] = []
+    intersected_faces: list[str] = []
 
-    planes: Dict[str, cq.Face] = {}
-    partitions: Dict[str, cq.Workplane] = {}
+    planes: dict[str, cq.Face] = {}
+    partitions: dict[str, cq.Workplane] = {}
     for face in faces:
         planes[face] = cq.Face.makePlane(
             basePnt=basePnt[face], dir=direction[face]

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -4,7 +4,7 @@ Phase class to manage list of solids belonging to the same phase
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Tuple
+from typing import Sequence
 
 import cadquery as cq
 import numpy as np
@@ -29,13 +29,13 @@ class Phase:
 
     def __init__(
         self,
-        shape: Optional[cq.Shape] = None,
-        solids: Optional[List[cq.Solid]] = None,
-        center: Optional[Tuple[float, float, float]] = None,
-        orientation: Optional[Tuple[float, float, float]] = None,
+        shape: cq.Shape | None = None,
+        solids: list[cq.Solid] | None = None,
+        center: tuple[float, float, float] | None = None,
+        orientation: tuple[float, float, float] | None = None,
     ) -> None:
         self._shape = shape
-        self._solids: List[cq.Solid] = solids if solids is not None else []
+        self._solids: list[cq.Solid] = solids if solids is not None else []
         self.center = center
         self.orientation = orientation
 
@@ -102,7 +102,7 @@ class Phase:
         )
 
     @property
-    def shape(self) -> Optional[cq.Shape]:
+    def shape(self) -> cq.Shape | None:
         if self._shape is not None:
             return self._shape
         elif len(self._solids) > 0:
@@ -115,7 +115,7 @@ class Phase:
             return None
 
     @property
-    def solids(self) -> List[cq.Solid]:
+    def solids(self) -> list[cq.Solid]:
         if len(self._solids) > 0:
             return self._solids
         elif self._shape is not None:
@@ -131,7 +131,7 @@ class Phase:
 
     @staticmethod
     def rescaleShape(
-        shape: cq.Shape, scale: float | Tuple[float, float, float]
+        shape: cq.Shape, scale: float | tuple[float, float, float]
     ) -> cq.Shape:
         """
         Rescale given object according to scale parameters [dim_x, dim_y, dim_z]
@@ -161,7 +161,7 @@ class Phase:
 
         return shape
 
-    def rescale(self, scale: float | Tuple[float, float, float]) -> None:
+    def rescale(self, scale: float | tuple[float, float, float]) -> None:
         """
         Rescale phase according to scale parameters [dim_x, dim_y, dim_z]
 
@@ -194,7 +194,7 @@ class Phase:
 
     @staticmethod
     def repeatShape(
-        unit_geom: cq.Shape, rve: Rve, grid: Tuple[int, int, int]
+        unit_geom: cq.Shape, rve: Rve, grid: tuple[int, int, int]
     ) -> cq.Shape:
         """
         Repeats unit geometry in each direction according to the given grid
@@ -226,7 +226,7 @@ class Phase:
         shape = cq.Shape(compound.wrapped)
         return shape
 
-    def repeat(self, rve: Rve, grid: Tuple[int, int, int]) -> None:
+    def repeat(self, rve: Rve, grid: tuple[int, int, int]) -> None:
         """
         Repeats phase in each direction according to the given grid
 
@@ -235,7 +235,7 @@ class Phase:
         """
         self._shape = self.repeat_shape(self.shape, rve, grid)
 
-    def split_solids(self, rve: Rve, grid: List[int]) -> List[cq.Solid]:
+    def split_solids(self, rve: Rve, grid: list[int]) -> list[cq.Solid]:
         """
         Split solids from phase according to the rve divided by the given grid
 
@@ -244,7 +244,7 @@ class Phase:
 
         :return: list of solids
         """
-        solids: List[cq.Solid] = []
+        solids: list[cq.Solid] = []
 
         for solid in self.solids:
             wk_plane = cq.Workplane().add(solid)
@@ -265,8 +265,8 @@ class Phase:
         return solids
 
     def rasterize(
-        self, rve: Rve, grid: List[int], phasePerRaster: bool = True
-    ) -> Optional[List[Phase]]:
+        self, rve: Rve, grid: list[int], phasePerRaster: bool = True
+    ) -> list[Phase] | None:
         """
         Rasters solids from phase according to the rve divided by the given grid
 
@@ -299,7 +299,7 @@ class Phase:
         :return: list of Phases
         """
         grid = np.array(grid)
-        solids_phases: List[List[cq.Solid]] = [[] for _ in range(np.prod(grid))]
+        solids_phases: list[list[cq.Solid]] = [[] for _ in range(np.prod(grid))]
         for solid in solids:
             center = np.array(solid.Center().toTuple())
             i, j, k = np.floor(grid * (center - rve.min_point) / rve.dim).astype(int)
@@ -309,8 +309,8 @@ class Phase:
 
     @classmethod
     def generatePhasePerRaster(
-        cls, solidList: List[cq.Solid], rve: Rve, grid: List[int]
-    ) -> List[Phase]:
+        cls, solidList: list[cq.Solid], rve: Rve, grid: list[int]
+    ) -> list[Phase]:
         """
         Rasters solids from phase according to the rve divided by the given grid
 
@@ -320,7 +320,7 @@ class Phase:
 
         :return: list of Phases
         """
-        solids_phases: List[List[cq.Solid]] = [
+        solids_phases: list[list[cq.Solid]] = [
             [] for _ in range(grid[0] * grid[1] * grid[2])
         ]
         for solid in solidList:

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, Union, overload
+from typing import overload
 
 import pyvista as pv
 
@@ -21,11 +23,11 @@ def remesh_keeping_periodicity_for_fem(
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
-    hausd: Optional[float] = None,
-    hgrad: Optional[float] = None,
-    hmax: Optional[float] = None,
-    hmin: Optional[float] = None,
-    hsiz: Optional[float] = None,
+    hausd: float | None = None,
+    hgrad: float | None = None,
+    hmax: float | None = None,
+    hmin: float | None = None,
+    hsiz: float | None = None,
 ) -> BoxMesh: ...
 
 
@@ -35,25 +37,25 @@ def remesh_keeping_periodicity_for_fem(
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
-    hausd: Optional[float] = None,
-    hgrad: Optional[float] = None,
-    hmax: Optional[float] = None,
-    hmin: Optional[float] = None,
-    hsiz: Optional[float] = None,
+    hausd: float | None = None,
+    hgrad: float | None = None,
+    hmax: float | None = None,
+    hmin: float | None = None,
+    hsiz: float | None = None,
 ) -> pv.UnstructuredGrid: ...
 
 
 def remesh_keeping_periodicity_for_fem(
-    input_mesh: Union[BoxMesh, pv.UnstructuredGrid],
+    input_mesh: BoxMesh | pv.UnstructuredGrid,
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
-    hausd: Optional[float] = None,
-    hgrad: Optional[float] = None,
-    hmax: Optional[float] = None,
-    hmin: Optional[float] = None,
-    hsiz: Optional[float] = None,
-) -> Union[BoxMesh, pv.UnstructuredGrid]:
+    hausd: float | None = None,
+    hgrad: float | None = None,
+    hmax: float | None = None,
+    hmin: float | None = None,
+    hsiz: float | None = None,
+) -> BoxMesh | pv.UnstructuredGrid:
     """
     Remeshes a mesh using mmg while keeping periodicity
 
@@ -207,5 +209,5 @@ def _remove_unnecessary_fields_from_mesh_file(
         output_file.write("End\n")
 
 
-def _only_numbers_in_line(line: List[str]) -> bool:
+def _only_numbers_in_line(line: list[str]) -> bool:
     return all(not flag.isalpha() for flag in line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.2.1"
 authors = [{ name = "3MAH", email = 'set3mah@gmail.com' }]
 description = "Microstructure generation and meshing"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["microstructure", "lattice", "periodic", "TPMS", "mesh"]
 license = { text = "GPLv3" }
 classifiers = [
@@ -17,7 +17,6 @@ classifiers = [
     'Operating System :: Microsoft :: Windows',
     'Operating System :: POSIX',
     'Operating System :: MacOS',
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tests/test_box_mesh.py
+++ b/tests/test_box_mesh.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import math as m
 import random
-from typing import Dict, List, Tuple
 
 import numpy as np
 import numpy.typing as npt
 import pytest
 import pyvista as pv
-from microgen import BoxMesh, Rve
 from pytest import FixtureRequest
+
+from microgen import BoxMesh, Rve
 
 
 def _box_mesh_points() -> npt.NDArray[np.float_]:
@@ -45,7 +47,7 @@ def _box_mesh_points() -> npt.NDArray[np.float_]:
     return points
 
 
-def _box_mesh_elements() -> Dict[pv.CellType, npt.NDArray[np.int_]]:
+def _box_mesh_elements() -> dict[pv.CellType, npt.NDArray[np.int_]]:
     elements_dict = {
         pv.CellType.TETRA: np.array(
             [
@@ -105,14 +107,14 @@ def _box_mesh_elements() -> Dict[pv.CellType, npt.NDArray[np.int_]]:
 
 
 @pytest.fixture(scope="function")
-def default_box_mesh() -> Tuple[BoxMesh, Rve]:
+def default_box_mesh() -> tuple[BoxMesh, Rve]:
     mesh = BoxMesh(_box_mesh_points(), _box_mesh_elements())
     rve = Rve(dim=(1, 1, 1), center=(0.5, 0.5, 0.5))
     return (mesh, rve)
 
 
 @pytest.fixture(scope="function")
-def expanded_box_mesh_x() -> Tuple[BoxMesh, Rve]:
+def expanded_box_mesh_x() -> tuple[BoxMesh, Rve]:
     expanded_mesh = _box_mesh_points()
     expanded_mesh[:, 0] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
@@ -121,7 +123,7 @@ def expanded_box_mesh_x() -> Tuple[BoxMesh, Rve]:
 
 
 @pytest.fixture(scope="function")
-def expanded_box_mesh_y() -> Tuple[BoxMesh, Rve]:
+def expanded_box_mesh_y() -> tuple[BoxMesh, Rve]:
     expanded_mesh = _box_mesh_points()
     expanded_mesh[:, 1] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
@@ -130,7 +132,7 @@ def expanded_box_mesh_y() -> Tuple[BoxMesh, Rve]:
 
 
 @pytest.fixture(scope="function")
-def expanded_box_mesh_z() -> Tuple[BoxMesh, Rve]:
+def expanded_box_mesh_z() -> tuple[BoxMesh, Rve]:
     expanded_mesh = _box_mesh_points()
     expanded_mesh[:, 2] *= 3.0
     mesh = BoxMesh(expanded_mesh, _box_mesh_elements())
@@ -172,9 +174,9 @@ def test_given_box_mesh_construct_must_find_center_corners_edges_faces_node_sets
 ) -> None:
     box_mesh_to_test, rve = request.getfixturevalue(box_mesh)
     target_center: npt.NDArray[np.float_] = rve.center
-    target_corners: List[int] = [0, 2, 6, 8, 18, 20, 24, 26]
-    target_edges: List[int] = [1, 3, 5, 7, 9, 11, 15, 17, 19, 21, 23, 25]
-    target_faces: List[int] = [4, 10, 12, 14, 16, 22]
+    target_corners: list[int] = [0, 2, 6, 8, 18, 20, 24, 26]
+    target_edges: list[int] = [1, 3, 5, 7, 9, 11, 15, 17, 19, 21, 23, 25]
+    target_faces: list[int] = [4, 10, 12, 14, 16, 22]
 
     box_mesh_corners = sorted(np.concatenate(list(box_mesh_to_test.corners.values())))
     box_mesh_edges = sorted(np.concatenate(list(box_mesh_to_test.edges.values())))
@@ -243,7 +245,7 @@ def test_closest_points_on_boundaries_periodic_mesh_must_have_only_one_neighbour
         k_neighbours=k_neighbours
     )
 
-    number_of_closest_neighbours_to_test: List[int] = []
+    number_of_closest_neighbours_to_test: list[int] = []
     number_closest_neighbours_truth_1_on_each_face_and_edge = [1] * 12
     for key, list_of_neighbour_for_all_nodes in closest_pts.items():
         list_of_neighbour_for_all_nodes_index = list_of_neighbour_for_all_nodes[0]
@@ -304,7 +306,7 @@ def test_closest_points_on_perturbated_mesh_boundaries_must_have_good_number_of_
         2,
         2,
     ]
-    number_of_closest_neighbours_to_test: List[int] = []
+    number_of_closest_neighbours_to_test: list[int] = []
     for _, list_of_neighbour_for_all_nodes in closest_pts.items():
         list_of_neighbour_for_all_nodes_index = list_of_neighbour_for_all_nodes[0]
 

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List, Tuple, Union
 
 import cadquery as cq
 import numpy as np
@@ -68,8 +69,8 @@ def _generate_cqcompound_octettruss(rve: Rve):
     height = np.full_like(xc, 2.0)
     radius = np.full_like(xc, 0.05)
 
-    listPhases: List[Phase] = []
-    list_periodic_phases: List[Phase] = []
+    listPhases: list[Phase] = []
+    list_periodic_phases: list[Phase] = []
     n = len(xc)
 
     for i in range(0, n):
@@ -90,7 +91,7 @@ def _generate_cqcompound_octettruss(rve: Rve):
 
 
 @pytest.fixture(scope="function")
-def box_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
+def box_homogeneous_unit(rve_unit: Rve) -> tuple[cq.Shape, list[Phase], Rve]:
     shape = Box(
         center=tuple(rve_unit.center),
         orientation=(0.0, 0.0, 0.0),
@@ -103,7 +104,7 @@ def box_homogeneous_unit(rve_unit: Rve) -> Tuple[cq.Shape, List[Phase], Rve]:
 @pytest.fixture(scope="function")
 def box_homogeneous_double(
     rve_double: Rve,
-) -> Tuple[cq.Shape, List[Phase], Rve]:
+) -> tuple[cq.Shape, list[Phase], Rve]:
     shape = Box(
         center=tuple(rve_double.center),
         orientation=(0.0, 0.0, 0.0),
@@ -116,7 +117,7 @@ def box_homogeneous_double(
 @pytest.fixture(scope="function")
 def box_homogeneous_double_centered(
     rve_double_centered: Rve,
-) -> (cq.Shape, List[Phase], Rve):
+) -> (cq.Shape, list[Phase], Rve):
     shape = Box(
         center=tuple(rve_double_centered.center),
         orientation=(0.0, 0.0, 0.0),
@@ -129,7 +130,7 @@ def box_homogeneous_double_centered(
 @pytest.fixture(scope="function")
 def octet_truss_homogeneous_unit(
     rve_unit: Rve,
-) -> Tuple[cq.Shape, List[Phase], Rve]:
+) -> tuple[cq.Shape, list[Phase], Rve]:
     list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
     merged = fuseShapes(
         [phase.shape for phase in list_periodic_phases], retain_edges=False
@@ -141,7 +142,7 @@ def octet_truss_homogeneous_unit(
 @pytest.fixture(scope="function")
 def octet_truss_homogeneous_double_centered(
     rve_double_centered: Rve,
-) -> Tuple[cq.Shape, List[Phase], Rve]:
+) -> tuple[cq.Shape, list[Phase], Rve]:
     list_periodic_phases = _generate_cqcompound_octettruss(rve_double_centered)
     merged = fuseShapes(
         [phase.shape for phase in list_periodic_phases], retain_edges=False
@@ -153,7 +154,7 @@ def octet_truss_homogeneous_double_centered(
 @pytest.fixture(scope="function")
 def octet_truss_heterogeneous(
     rve_unit: Rve,
-) -> Tuple[cq.Compound, List[Phase], Rve]:
+) -> tuple[cq.Compound, list[Phase], Rve]:
     list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
     listcqphases = cutPhases(phaseList=list_periodic_phases, reverseOrder=False)
     return (
@@ -175,7 +176,7 @@ def octet_truss_heterogeneous(
     ],
 )
 def test_octettruss_mesh_must_be_periodic(
-    shape: Tuple[Union[cq.Compound, cq.Shape], List[Phase], Rve],
+    shape: tuple[cq.Compound | cq.Shape, list[Phase], Rve],
     request,
     tmp_output_compound_filename: str,
     tmp_output_vtk_filename: str,

--- a/tests/test_single_mesh.py
+++ b/tests/test_single_mesh.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from __future__ import annotations
 
 import numpy as np
 import numpy.typing as npt
@@ -10,8 +10,8 @@ from microgen.single_mesh import NotOnlyLinearTetrahedraError
 
 
 def are_elements_equal(
-    dict1: Dict[pv.CellType, npt.NDArray[np.int_]],
-    dict2: Dict[pv.CellType, npt.NDArray[np.int_]],
+    dict1: dict[pv.CellType, npt.NDArray[np.int_]],
+    dict2: dict[pv.CellType, npt.NDArray[np.int_]],
 ) -> bool:
     """Return whether two dictionaries of arrays are equal"""
     if dict1.keys() != dict2.keys():
@@ -75,7 +75,7 @@ def _box_single_mesh_nodes() -> npt.NDArray[np.float_]:
     return nodes_array
 
 
-def _box_single_mesh_elements() -> Dict[pv.CellType, npt.NDArray[np.int_]]:
+def _box_single_mesh_elements() -> dict[pv.CellType, npt.NDArray[np.int_]]:
     elements_dict = {
         pv.CellType.TETRA: np.array(
             [
@@ -315,12 +315,12 @@ def _linear_3d_pyramid_mesh() -> pv.UnstructuredGrid:
 
 
 @pytest.fixture(name="sample_1d_mesh_list", scope="function")
-def fixture_sample_1d_mesh_list() -> List[pv.UnstructuredGrid]:
+def fixture_sample_1d_mesh_list() -> list[pv.UnstructuredGrid]:
     return [_linear_1d_mesh(), _quadratic_1d_mesh()]
 
 
 @pytest.fixture(name="sample_2d_mesh_list", scope="function")
-def fixture_sample_2d_mesh_list() -> List[pv.UnstructuredGrid]:
+def fixture_sample_2d_mesh_list() -> list[pv.UnstructuredGrid]:
     return [
         _linear_2d_quad_mesh(),
         _quadratic_2d_quad_mesh(),
@@ -330,7 +330,7 @@ def fixture_sample_2d_mesh_list() -> List[pv.UnstructuredGrid]:
 
 
 @pytest.fixture(name="sample_3d_non_linear_tet_mesh_list", scope="function")
-def fixture_sample_3d_non_linear_tet_mesh_list() -> List[pv.UnstructuredGrid]:
+def fixture_sample_3d_non_linear_tet_mesh_list() -> list[pv.UnstructuredGrid]:
     return [
         _quadratic_3d_tet_mesh(),
         _linear_3d_hex_mesh(),
@@ -402,7 +402,7 @@ def test_single_mesh_consistency_when_extracting_surface_mesh(
 
 
 def test_given_sample_1d_mesh__check_if_only_linear_tetrahedral_must_raise_1d_warning(
-    sample_1d_mesh_list: List[pv.UnstructuredGrid],
+    sample_1d_mesh_list: list[pv.UnstructuredGrid],
 ) -> None:
     warning_message = (
         "1D elements are present in the PyVista UnstructuredGrid. They will be ignored."
@@ -413,7 +413,7 @@ def test_given_sample_1d_mesh__check_if_only_linear_tetrahedral_must_raise_1d_wa
 
 
 def test_given_sample_2d_mesh__check_if_only_linear_tetrahedral_must_raise_2d_warning(
-    sample_2d_mesh_list: List[pv.UnstructuredGrid],
+    sample_2d_mesh_list: list[pv.UnstructuredGrid],
 ) -> None:
     warning_message = (
         "2D elements are present in the PyVista UnstructuredGrid. They will be ignored."
@@ -424,7 +424,7 @@ def test_given_sample_2d_mesh__check_if_only_linear_tetrahedral_must_raise_2d_wa
 
 
 def test_given_sample_3d_mesh__check_if_only_linear_tetrahedral_must_raise_found_non_linear_tet_elements_error(
-    sample_3d_non_linear_tet_mesh_list: List[pv.UnstructuredGrid],
+    sample_3d_non_linear_tet_mesh_list: list[pv.UnstructuredGrid],
 ) -> None:
     error_message_snippet = "Mesh contains elements other than linear tetrahedra."
     with pytest.raises(NotOnlyLinearTetrahedraError, match=error_message_snippet):


### PR DESCRIPTION
This PR is dropping support of Python 3.8 following its end of life since October 14th ([Status of Python versions](https://devguide.python.org/versions/)).