### PR TITLE
Bugfix/remesh

### DIFF
--- a/examples/Mesh/remesh/remesh.py
+++ b/examples/Mesh/remesh/remesh.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from microgen import Tpms
-from microgen.remesh import remesh_keeping_periodicity_for_fem
+from microgen.remesh import remesh_keeping_boundaries_for_fem
 from microgen.shape.surface_functions import gyroid
 
 data_dir = Path(__file__).parent / "data"
@@ -14,7 +14,7 @@ initial_gyroid = tpms.grid_sheet
 initial_gyroid.save(data_dir / "initial_gyroid_mesh.vtk")
 
 max_element_edge_length = 0.02
-remeshed_gyroid = remesh_keeping_periodicity_for_fem(
+remeshed_gyroid = remesh_keeping_boundaries_for_fem(
     initial_gyroid,
     hmax=max_element_edge_length,
 )

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import overload
@@ -12,11 +13,13 @@ from microgen import BoxMesh, Mmg, is_periodic
 
 
 class InputMeshNotPeriodicError(Exception):
-    """Raised when input mesh of remesh_keeping_boundaries_for_fem is not periodic."""
+    """Raised when input mesh of remesh_keeping_boundaries_for_fem
+    with periodic=True option is not periodic."""
 
 
 class OutputMeshNotPeriodicError(Exception):
-    """Raised when output mesh of remesh_keeping_boundaries_for_fem is not periodic."""
+    """Raised when output mesh of remesh_keeping_boundaries_for_fem
+    with periodic=True option is not periodic."""
 
 
 @overload
@@ -225,3 +228,38 @@ def _remove_unnecessary_fields_from_mesh_file(
 
 def _only_numbers_in_line(line: list[str]) -> bool:
     return all(not flag.isalpha() for flag in line)
+
+
+def remesh_keeping_periodicity_for_fem(
+    input_mesh: BoxMesh | pv.UnstructuredGrid,
+    mesh_version: int = 2,
+    dimension: int = 3,
+    tol: float = 1e-8,
+    hausd: float | None = None,
+    hgrad: float | None = None,
+    hmax: float | None = None,
+    hmin: float | None = None,
+    hsiz: float | None = None,
+) -> BoxMesh | pv.UnstructuredGrid:
+    """See remesh_keeping_boundaries_for_fem.
+
+    Deprecated in favor of remesh_keeping_boundaries_for_fem.
+    """
+    warnings.warn(
+        "remesh_keeping_periodicity_for_fem is deprecated, use remesh_keeping_boundaries_for_fem instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return remesh_keeping_boundaries_for_fem(
+        input_mesh,
+        periodic=True,
+        mesh_version=mesh_version,
+        dimension=dimension,
+        tol=tol,
+        hausd=hausd,
+        hgrad=hgrad,
+        hmax=hmax,
+        hmin=hmin,
+        hsiz=hsiz,
+    )

--- a/microgen/remesh.py
+++ b/microgen/remesh.py
@@ -1,4 +1,4 @@
-"""Remesh a mesh using mmg while keeping periodicity."""
+"""Remesh a mesh using mmg while keeping boundaries untouched."""
 
 from __future__ import annotations
 
@@ -12,16 +12,17 @@ from microgen import BoxMesh, Mmg, is_periodic
 
 
 class InputMeshNotPeriodicError(Exception):
-    """Raised when input mesh of remesh_keeping_periodicity_for_fem is not periodic."""
+    """Raised when input mesh of remesh_keeping_boundaries_for_fem is not periodic."""
 
 
 class OutputMeshNotPeriodicError(Exception):
-    """Raised when output mesh of remesh_keeping_periodicity_for_fem is not periodic."""
+    """Raised when output mesh of remesh_keeping_boundaries_for_fem is not periodic."""
 
 
 @overload
-def remesh_keeping_periodicity_for_fem(
+def remesh_keeping_boundaries_for_fem(
     input_mesh: BoxMesh,
+    periodic: bool = True,
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
@@ -34,8 +35,9 @@ def remesh_keeping_periodicity_for_fem(
 
 
 @overload
-def remesh_keeping_periodicity_for_fem(
+def remesh_keeping_boundaries_for_fem(
     input_mesh: pv.UnstructuredGrid,
+    periodic: bool = True,
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
@@ -47,8 +49,9 @@ def remesh_keeping_periodicity_for_fem(
 ) -> pv.UnstructuredGrid: ...
 
 
-def remesh_keeping_periodicity_for_fem(
+def remesh_keeping_boundaries_for_fem(
     input_mesh: BoxMesh | pv.UnstructuredGrid,
+    periodic: bool = True,
     mesh_version: int = 2,
     dimension: int = 3,
     tol: float = 1e-8,
@@ -58,9 +61,10 @@ def remesh_keeping_periodicity_for_fem(
     hmin: float | None = None,
     hsiz: float | None = None,
 ) -> BoxMesh | pv.UnstructuredGrid:
-    """Remesh a mesh using mmg while keeping periodicity.
+    """Remesh a mesh using mmg while keeping boundary elements untouched.
 
     :param input_mesh: BoxMesh or pv.UnstructuredGrid mesh to be remeshed
+    :param periodic: whether the mesh is periodic and must stay periodic (default: True)
     :param mesh_version: mesh file version (default: 2)
     :param dimension: mesh dimension (default: 3)
     :param tol: tolerance for periodicity check
@@ -90,7 +94,7 @@ def remesh_keeping_periodicity_for_fem(
         err_msg = "Input mesh must be either a BoxMesh or a pv.UnstructuredGrid"
         raise TypeError(err_msg)
 
-    if not is_periodic(nodes_coords, tol, dimension):
+    if periodic and not is_periodic(nodes_coords, tol, dimension):
         err_msg = "Input mesh is not periodic"
         raise InputMeshNotPeriodicError(err_msg)
 
@@ -130,7 +134,7 @@ def remesh_keeping_periodicity_for_fem(
 
     output_mesh = pv.UnstructuredGrid(output_mesh_file.name)
 
-    if not is_periodic(output_mesh.points, tol, dimension):
+    if periodic and not is_periodic(output_mesh.points, tol, dimension):
         err_msg = "Something went wrong: output mesh is not periodic"
         raise OutputMeshNotPeriodicError(err_msg)
 

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -9,10 +9,7 @@ import pyvista as pv
 from _pytest.fixtures import FixtureRequest
 
 from microgen import BoxMesh, Tpms, is_periodic
-from microgen.remesh import (
-    InputMeshNotPeriodicError,
-    remesh_keeping_periodicity_for_fem,
-)
+from microgen.remesh import InputMeshNotPeriodicError, remesh_keeping_boundaries_for_fem
 from microgen.shape.surface_functions import gyroid
 
 # ruff: noqa: S101 assert https://docs.astral.sh/ruff/rules/assert/
@@ -185,7 +182,7 @@ def test_given_periodic_mesh_remesh_keeping_periodicity_for_fem_must_maintain_pe
     # Act
     if USE_MMG:
         edge_length_gradient = 1.05
-        remeshed_shape = remesh_keeping_periodicity_for_fem(
+        remeshed_shape = remesh_keeping_boundaries_for_fem(
             input_mesh,
             hgrad=edge_length_gradient,
         )
@@ -208,7 +205,7 @@ def test_given_non_periodic_mesh_remesh_must_raise_inputmeshnotperiodicerror(
             InputMeshNotPeriodicError,
             match="Input mesh is not periodic",
         ):
-            remesh_keeping_periodicity_for_fem(
+            remesh_keeping_boundaries_for_fem(
                 non_periodic_mesh,
                 hgrad=edge_length_gradient,
             )

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -16,9 +16,6 @@ from microgen.shape.surface_functions import gyroid
 # ruff: noqa: E501 line-too-long https://docs.astral.sh/ruff/rules/line-too-long/
 
 
-_MESH_DIM = 3
-_BOUNDARY_DIM = 2
-
 USE_MMG = shutil.which("mmg3d_O3") is not None
 if not USE_MMG:
     warnings.warn("MMG will not be used in these tests", stacklevel=2)
@@ -172,11 +169,11 @@ def fixture_non_periodic_mesh() -> pv.UnstructuredGrid:
         "gyroid_mesh",
     ],
 )
-def test_given_periodic_mesh_remesh_keeping_periodicity_for_fem_must_maintain_periodicity(
+def test_given_periodic_mesh_remesh_keeping_boundaries_for_fem_with_periodic_option_must_maintain_periodicity(
     shape: str,
     request: FixtureRequest,
 ) -> None:
-    """Test that remesh_keeping_periodicity_for_fem maintains periodicity."""
+    """Tests that remesh_keeping_boundaries_for_fem with periodic=True maintains periodicity."""
     # Arrange
     input_mesh = request.getfixturevalue(shape)
     # Act
@@ -195,10 +192,10 @@ def test_given_periodic_mesh_remesh_keeping_periodicity_for_fem_must_maintain_pe
         assert is_periodic(remeshed_shape.points)
 
 
-def test_given_non_periodic_mesh_remesh_must_raise_inputmeshnotperiodicerror(
+def test_given_non_periodic_mesh_remesh_with_periodic_option_must_raise_inputmeshnotperiodicerror(
     non_periodic_mesh: pv.UnstructuredGrid,
 ) -> None:
-    """Test that remesh_keeping_periodicity_for_fem raises InputMeshNotPeriodicError."""
+    """Tests that remesh_keeping_boundaries_for_fem raises InputMeshNotPeriodicError."""
     if USE_MMG:
         edge_length_gradient = 1.05
         with pytest.raises(
@@ -209,3 +206,44 @@ def test_given_non_periodic_mesh_remesh_must_raise_inputmeshnotperiodicerror(
                 non_periodic_mesh,
                 hgrad=edge_length_gradient,
             )
+
+
+def test_given_non_periodic_mesh_remesh_without_periodic_option_must_remesh_keeping_boundaries_intact(
+    non_periodic_mesh: pv.UnstructuredGrid,
+) -> None:
+    """Tests that remesh_keeping_boundaries_for_fem with periodic=False
+    remeshes the mesh while keeping boundaries intact."""
+
+    # Arrange
+
+    BOUNDARY_ELEMENTS_POLYDATA_INDEX = 0
+    initial_mesh_nodes_coords = non_periodic_mesh.points
+    initial_mesh_boundary_nodes_coords = (
+        BoxMesh.from_pyvista(non_periodic_mesh)
+        .boundary_elements()[BOUNDARY_ELEMENTS_POLYDATA_INDEX]
+        .points
+    )
+
+    # Act
+
+    if USE_MMG:
+        edge_length_gradient = 1.05
+        remeshed_mesh = remesh_keeping_boundaries_for_fem(
+            non_periodic_mesh,
+            periodic=False,
+            hgrad=edge_length_gradient,
+        )
+        remeshed_mesh_nodes_coords = remeshed_mesh.points
+        remeshed_mesh_boundary_nodes_coords = (
+            BoxMesh.from_pyvista(remeshed_mesh)
+            .boundary_elements()[BOUNDARY_ELEMENTS_POLYDATA_INDEX]
+            .points
+        )
+
+        # Assert
+
+        assert not np.array_equal(initial_mesh_nodes_coords, remeshed_mesh_nodes_coords)
+        assert np.allclose(
+            np.sort(initial_mesh_boundary_nodes_coords.flat),
+            np.sort(remeshed_mesh_boundary_nodes_coords.flat),
+        )


### PR DESCRIPTION
This PR changes `remesh.py`:

- The remesher now works in case the user wants to remesh while keeping the boundary elements untouched, regardless of periodicity

- `remesh_keeping_periodicity_for_fem` has been renamed to `remesh_keeping_boundaries_for_fem`. To ensure backwards compatibility, `remesh_keeping_periodicity_for_fem` can still be called but raises a deprecation warning

- A new parameter has been added to remesh_keeping_boundaries_for_fem: if `periodic=True` (default), the remesher will check for periodicity before and after the operation (ie: the previous `remesh_keeping_periodicity_for_fem` behavior)

The relevant test has been added to `test_remesh.py`