### PR TITLE
Add CITATION.cff and .zenodo.json, switch README to concept DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
-  "title": "Microgen: Microstructure generation and meshing",
-  "description": "Microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations.",
+  "title": "microgen: microstructure generation and meshing",
+  "description": "microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations.",
   "license": "GPL-3.0-only",
   "upload_type": "software",
   "access_right": "open",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -16,7 +16,8 @@
   "creators": [
     {
       "name": "Marchais, Kevin",
-      "affiliation": "Hivelix"
+      "affiliation": "Hivelix",
+      "orcid": "0000-0001-8842-6329"
     },
     {
       "name": "Chemisky, Yves",
@@ -34,7 +35,8 @@
   "contributors": [
     {
       "name": "Le Barbenchon, Louise",
-      "affiliation": "",
+      "affiliation": "Institut de Mécanique et d'Ingénierie",
+      "orcid": "0000-0002-5631-248X",
       "type": "ProjectMember"
     },
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "d'Esparbès, Romain",
-      "affiliation": "",
+      "affiliation": "GEOSAT 3D",
       "type": "ProjectMember"
     },
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -25,7 +25,8 @@
     },
     {
       "name": "Legerstee, Yasmin",
-      "affiliation": ""
+      "affiliation": "Institut de Mécanique et d'Ingénierie",
+      "orcid": "0009-0001-5249-2882"
     },
     {
       "name": "Guevara Garban, Manuel Ricardo",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,63 @@
+{
+  "title": "Microgen: Microstructure generation and meshing",
+  "description": "Microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations.",
+  "license": "GPL-3.0-only",
+  "upload_type": "software",
+  "access_right": "open",
+  "keywords": [
+    "microstructure",
+    "lattice",
+    "periodic",
+    "TPMS",
+    "mesh",
+    "F-rep",
+    "Voronoi"
+  ],
+  "creators": [
+    {
+      "name": "Marchais, Kevin",
+      "affiliation": "Hivelix"
+    },
+    {
+      "name": "Chemisky, Yves",
+      "affiliation": ""
+    },
+    {
+      "name": "Legerstee, Yasmin",
+      "affiliation": ""
+    },
+    {
+      "name": "Guevara Garban, Manuel Ricardo",
+      "affiliation": ""
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Le Barbenchon, Louise",
+      "affiliation": "",
+      "type": "ProjectMember"
+    },
+    {
+      "name": "Haffar, Karim",
+      "affiliation": "",
+      "type": "ProjectMember"
+    },
+    {
+      "name": "d'Esparbès, Romain",
+      "affiliation": "",
+      "type": "ProjectMember"
+    },
+    {
+      "name": "Sahoo, Sudeep Kumar",
+      "affiliation": "",
+      "type": "ProjectMember"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/3MAH/microgen",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -21,29 +21,29 @@
     },
     {
       "name": "Chemisky, Yves",
-      "affiliation": ""
+      "affiliation": "Université Grenoble Alpes - laboratoire TIMC"
     },
     {
       "name": "Legerstee, Yasmin",
-      "affiliation": "Institut de Mécanique et d'Ingénierie",
+      "affiliation": "Université de Bordeaux - laboratoire I2M",
       "orcid": "0009-0001-5249-2882"
     },
     {
       "name": "Guevara Garban, Manuel Ricardo",
-      "affiliation": "Institut de Mécanique et d'Ingénierie / TU Bergakademie Freiberg",
+      "affiliation": "Université de Bordeaux - laboratoire I2M / TU Bergakademie Freiberg",
       "orcid": "0009-0007-8208-3020",
     }
   ],
   "contributors": [
     {
       "name": "Le Barbenchon, Louise",
-      "affiliation": "Institut de Mécanique et d'Ingénierie",
+      "affiliation": "CNRS - laboratoire I2M",
       "orcid": "0000-0002-5631-248X",
       "type": "ProjectMember"
     },
     {
       "name": "Haffar, Karim",
-      "affiliation": "",
+      "affiliation": "Université Grenoble Alpes - laboratoire TIMC",
       "type": "ProjectMember"
     },
     {
@@ -53,7 +53,7 @@
     },
     {
       "name": "Sahoo, Sudeep Kumar",
-      "affiliation": "",
+      "affiliation": "Titan Company Limited",
       "type": "ProjectMember"
     }
   ],

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -29,7 +29,8 @@
     },
     {
       "name": "Guevara Garban, Manuel Ricardo",
-      "affiliation": ""
+      "affiliation": "Institut de Mécanique et d'Ingénierie / TU Bergakademie Freiberg",
+      "orcid": "0009-0007-8208-3020",
     }
   ],
   "contributors": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,11 +10,11 @@ authors:
     orcid: "https://orcid.org/0000-0001-8842-6329"
   - family-names: Chemisky
     given-names: Yves
-    affiliation: ""
-    # orcid: "https://orcid.org/0000-0000-0000-0000"
+    affiliation: "Université Grenoble Alpes - laboratoire TIMC"
+    orcid: "https://orcid.org/0000-0002-8725-9554"
   - family-names: Legerstee
     given-names: Yasmin
-    affiliation: "Université de Bordeaux"
+    affiliation: "Université de Bordeaux - laboratoire I2M"
     orcid: "https://orcid.org/0009-0001-5249-2882"
   - family-names: Guevara Garban
     given-names: Manuel Ricardo
@@ -27,6 +27,7 @@ keywords:
   - microstructure
   - lattice
   - periodic
+  - implicit surface
   - TPMS
   - mesh
   - F-rep

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use Microgen in your research, please cite it using the metadata below."
-title: "Microgen: Microstructure generation and meshing"
-abstract: "Microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations."
+title: "microgen: microstructure generation and meshing"
+abstract: "microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations."
 type: software
 authors:
   - family-names: Marchais

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
     # orcid: "https://orcid.org/0000-0000-0000-0000"
   - family-names: Legerstee
     given-names: Yasmin
-    affiliation: ""
-    # orcid: "https://orcid.org/0000-0000-0000-0000"
+    affiliation: "Université de Bordeaux"
+    orcid: "https://orcid.org/0009-0001-5249-2882"
   - family-names: Guevara Garban
     given-names: Manuel Ricardo
     affiliation: "Université de Bordeaux / TU Bergakademie Freiberg"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,8 +18,8 @@ authors:
     # orcid: "https://orcid.org/0000-0000-0000-0000"
   - family-names: Guevara Garban
     given-names: Manuel Ricardo
-    affiliation: ""
-    # orcid: "https://orcid.org/0000-0000-0000-0000"
+    affiliation: "Université de Bordeaux / TU Bergakademie Freiberg"
+    orcid: "https://orcid.org/0009-0007-8208-3020"
 repository-code: "https://github.com/3MAH/microgen"
 url: "https://3mah.github.io/microgen-docs/"
 license: GPL-3.0-only

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+message: "If you use Microgen in your research, please cite it using the metadata below."
+title: "Microgen: Microstructure generation and meshing"
+abstract: "Microgen is a Python library for the generation and meshing of microstructures, including repeated cells, strut-based and TPMS lattices, virtual composite microstructures, and 3D Voronoi tessellations."
+type: software
+authors:
+  - family-names: Marchais
+    given-names: Kevin
+    affiliation: "Hivelix"
+    orcid: "https://orcid.org/0000-0001-8842-6329"
+  - family-names: Chemisky
+    given-names: Yves
+    affiliation: ""
+    # orcid: "https://orcid.org/0000-0000-0000-0000"
+  - family-names: Legerstee
+    given-names: Yasmin
+    affiliation: ""
+    # orcid: "https://orcid.org/0000-0000-0000-0000"
+  - family-names: Guevara Garban
+    given-names: Manuel Ricardo
+    affiliation: ""
+    # orcid: "https://orcid.org/0000-0000-0000-0000"
+repository-code: "https://github.com/3MAH/microgen"
+url: "https://3mah.github.io/microgen-docs/"
+license: GPL-3.0-only
+keywords:
+  - microstructure
+  - lattice
+  - periodic
+  - TPMS
+  - mesh
+  - F-rep
+  - Voronoi
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.6793573
+    description: "Concept DOI (resolves to the latest version on Zenodo)"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://github.com/3MAH/microgen/blob/main/docs/_static/microgen.png?raw=true" alt="Microgen logo" width="100%"/>
 </p>
 
-**Microgen** is a Python library designed to facilitate microstructure generation and meshing. Here are its core features:
+**microgen** is a Python library designed to facilitate microstructure generation and meshing. Here are its core features:
 
 - **Repeated cells**: Generation of lattice structures such as octet trusses and honeycombs.
 - **Triply Periodic Minimal Surfaces (TPMS)**: TPMS-based lattice generation known for favorable physical (mechanical, thermal, ...) properties like low density and large surface area.
@@ -64,7 +64,7 @@ pytest tests -n auto
 
 ## Examples
 
-Click on the image to be redirected to the corresponding example on Microgen's documentation
+Click on the image to be redirected to the corresponding example on **microgen**'s documentation
 
 ### Basic shapes
 
@@ -141,7 +141,7 @@ Click on the image to be redirected to the corresponding example on Microgen's d
 
 ## Citation
 
-If you use Microgen in academic work, please cite it using the **concept DOI**, which always resolves to the latest archived version on Zenodo:
+If you use **microgen** in academic work, please cite it using the concept DOI, which always resolves to the latest archived version on Zenodo:
 
 > [10.5281/zenodo.6793573](https://doi.org/10.5281/zenodo.6793573)
 
@@ -153,7 +153,7 @@ A BibTeX entry suitable for the latest release:
                Chemisky, Yves and
                Legerstee, Yasmin and
                Guevara Garban, Manuel Ricardo},
-  title     = {{Microgen: Microstructure generation and meshing}},
+  title     = {{microgen: microstructure generation and meshing}},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.6793573},
   url       = {https://doi.org/10.5281/zenodo.6793573}
@@ -164,7 +164,7 @@ To cite a specific release instead of the concept, follow the concept DOI to its
 
 ## Authors and contributors
 
-Microgen is developed by the [3MAH](https://3mah.github.io/) group and external collaborators.
+**microgen** is developed by the [3MAH](https://3mah.github.io/) group and external collaborators.
 
 **Authors**
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Generation of 3D objects is achievable through functions that utilize Open CASCA
 | Conda forge package  | [![Conda](https://anaconda.org/conda-forge/microgen/badges/version.svg)](https://anaconda.org/conda-forge/microgen) |
 | Documentation  | [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://3mah.github.io/microgen-docs/) |
 | Status         | [![Status](https://github.com/3MAH/microgen/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/3MAH/microgen) |
-| Citation       | [![DOI](https://zenodo.org/badge/380437028.svg)](https://zenodo.org/badge/latestdoi/380437028) |
+| Citation       | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6793573.svg)](https://doi.org/10.5281/zenodo.6793573) |
 | License        | [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) |
 | Website        | [![Website](https://img.shields.io/badge/website-3MAH-blue)](https://3mah.github.io/) |
 | Binder         | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/3MAH/microgen/HEAD?urlpath=lab%2Ftree%2Fexamples%2Fjupyter_notebooks) |

--- a/README.md
+++ b/README.md
@@ -138,3 +138,44 @@ Click on the image to be redirected to the corresponding example on Microgen's d
 <a href="https://3mah.github.io/microgen-docs/examples/mesh.html#periodic-remeshing">
     <img src="https://raw.githubusercontent.com/3MAH/microgen/main/docs/_static/examples/remeshed_mesh.png" height="250">
 </a>
+
+## Citation
+
+If you use Microgen in academic work, please cite it using the **concept DOI**, which always resolves to the latest archived version on Zenodo:
+
+> [10.5281/zenodo.6793573](https://doi.org/10.5281/zenodo.6793573)
+
+A BibTeX entry suitable for the latest release:
+
+```bibtex
+@software{microgen,
+  author    = {Marchais, Kevin and
+               Chemisky, Yves and
+               Legerstee, Yasmin and
+               Guevara Garban, Manuel Ricardo},
+  title     = {{Microgen: Microstructure generation and meshing}},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.6793573},
+  url       = {https://doi.org/10.5281/zenodo.6793573}
+}
+```
+
+To cite a specific release instead of the concept, follow the concept DOI to its Zenodo page and pick the version DOI for the release you used. Machine-readable metadata is also available in [`CITATION.cff`](CITATION.cff).
+
+## Authors and contributors
+
+Microgen is developed by the [3MAH](https://3mah.github.io/) group and external collaborators.
+
+**Authors**
+
+- Kevin Marchais
+- Yves Chemisky
+- Yasmin Legerstee
+- Manuel Ricardo Guevara Garban
+
+**Contributors**
+
+- Louise Le Barbenchon
+- Karim Haffar
+- Romain d'Esparbès
+- Sudeep Kumar Sahoo


### PR DESCRIPTION
## Summary

- Adds `CITATION.cff` so GitHub's "Cite this repository" widget renders a proper citation entry, and to give Zenodo a canonical author list to read on each release.
- Adds `.zenodo.json` to express the authors-vs-contributors split that CFF cannot represent. Zenodo prioritises this file when both are present.
- Updates the README citation badge to use the **concept DOI** (`10.5281/zenodo.6793573`), which always resolves to the latest Zenodo release rather than a single fixed deposit.

## Notes for reviewers

- **Authors (CITATION.cff + Zenodo `creators`)**: Marchais, Chemisky, Legerstee, Guevara Garban. These are the people the citation will name.
- **Contributors (Zenodo `contributors`, type `ProjectMember`)**: Le Barbenchon, Haffar, d'Esparbès, Sahoo. Acknowledged on the Zenodo deposit, not in the citation.
- Most `affiliation` and `orcid` fields are intentionally left empty / commented. Each author/contributor is invited to push a follow-up commit (or amend this PR) filling in their own data.
- License declared as `GPL-3.0-only` (SPDX). The current `LICENSE` file is the bare GPLv3 text with no "or any later version" clause anywhere in the source, so `only` matches the repo state. Switch to `GPL-3.0-or-later` later if we want to opt into future GPL versions, but that's a deliberate licensing decision that should be discussed separately.
- No `version` / `date-released` in CITATION.cff: the citation is concept-level, mirroring the concept DOI. Zenodo will fill in version metadata automatically from the GitHub release tag.

## Test plan

- [ ] On the PR page, GitHub renders a "Cite this repository" widget on the right sidebar, and the BibTeX/APA output lists the four authors.
- [ ] README "Citation" badge resolves to https://doi.org/10.5281/zenodo.6793573 and the badge image renders.
- [ ] After merge + next release, Zenodo's deposit page shows 4 creators and 4 contributors with the correct labels.