### PR TITLE
Fix pyvista API drift, conda recipe, and dev-release workflow

### DIFF
--- a/.github/workflows/conda-packaging.yml
+++ b/.github/workflows/conda-packaging.yml
@@ -26,9 +26,11 @@ jobs:
       - name: Build Package
         shell: bash -l {0}
         env:
-          PACKAGE_VERSION: ${{ github.ref_name }}
           BRANCH_NAME: ${{ github.ref_name }}
         run: |
+          PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+          export PACKAGE_VERSION
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           conda install -y conda-build
           conda config --set anaconda_upload no
           conda-build conda.recipe -c conda-forge --output-folder .
@@ -38,5 +40,11 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
+          if [[ "$PACKAGE_VERSION" == *dev* || "$PACKAGE_VERSION" == *rc* \
+              || "$PACKAGE_VERSION" =~ [0-9]a[0-9] || "$PACKAGE_VERSION" =~ [0-9]b[0-9] ]]; then
+            UPLOAD_LABEL="dev"
+          else
+            UPLOAD_LABEL="main"
+          fi
           conda install -y anaconda-client
-          anaconda upload noarch/*.conda --force --no-progress
+          anaconda upload noarch/*.conda --force --no-progress -l "$UPLOAD_LABEL"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,14 +18,13 @@ requirements:
   run:
     - python >=3.10,<3.15
     - numpy
-    - vtk                 # unpinned — VTK 9.4+ unblocked (cadquery removed)
-    - pyvista             # unpinned — same reason
+    - vtk                 # VTK 9.4+ unblocked (cadquery removed)
+    - pyvista >=0.46      # cell_quality and flip_faces APIs
     - python-gmsh
     - meshio
-    - ocp                 # OCCT Python binding — enables the CAD path
+    - ocp                 # OCCT Python binding, enables the CAD path
     - scipy
-    - pip:
-      - autograd
+    - autograd
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pyvista >=0.46      # cell_quality and flip_faces APIs
     - python-gmsh
     - meshio
-    - ocp                 # OCCT Python binding, enables the CAD path
+    - ocp                 # OCCT Python binding — enables the CAD path
     - scipy
     - autograd
 

--- a/examples/TPMS/tpmsSphere/tpmsSphere.py
+++ b/examples/TPMS/tpmsSphere/tpmsSphere.py
@@ -11,7 +11,7 @@ geometry = Tpms(
     resolution=30,
 )
 shape = geometry.generateVtk(type_part="sheet")
-shape.flip_normals()
+shape = shape.flip_faces()
 
 sphere = pv.Sphere(radius=1.45)
 

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -2048,7 +2048,7 @@ class Infill(Tpms):
         Initialize the Infill object.
 
         :param obj: object in which the infill is generated. Normals must be oriented\
-                towards the outside of the object. Use the `flip_normals` method if\
+                towards the outside of the object. Use the `flip_faces` method if\
                      needed.
         :param surface_function: tpms function or custom function (f(x, y, z) = 0)
         :param offset: offset of the isosurface to generate thickness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 # (``.generate()`` → OCCT ``TopoDS_Shape``) requires the ``[cad]`` extra.
 dependencies = [
     "numpy",
-    "pyvista",
+    "pyvista>=0.46",
     "gmsh",
     "meshio",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microgen"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 authors = [{ name = "3MAH", email = 'set3mah@gmail.com' }]
 description = "Microstructure generation and meshing"
 readme = "README.md"

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -43,5 +43,5 @@ def test_mesh_rastered_sphere_must_have_correct_number_of_cells() -> None:
     assert vtk_mesh["CellEntityIds"].shape[0] == vtk_mesh.n_cells > 0
     assert len(np.unique(vtk_mesh["CellEntityIds"])) == np.prod(grid)
 
-    mesh_quality = np.mean(vtk_mesh.compute_cell_quality()["CellQuality"])
+    mesh_quality = np.mean(vtk_mesh.cell_quality()["scaled_jacobian"])
     assert mesh_quality > MESH_QUALITY_THRESHOLD


### PR DESCRIPTION
Fixes the three failing CI jobs on `main` plus two release-workflow bugs.

**pyvista API drift** (newer release dropped deprecated aliases after netlib unpinned `pyvista`):
- `tests/test_mesh.py`: `compute_cell_quality()["CellQuality"]` to `cell_quality()["scaled_jacobian"]`.
- `examples/TPMS/tpmsSphere/tpmsSphere.py`: `shape.flip_normals()` to `shape = shape.flip_faces()`.
- Pin `pyvista >=0.46` in `pyproject.toml` and the conda recipe.

**Conda recipe** (`conda.recipe/meta.yaml`): drop the unsupported `pip: [autograd]` dict; add `autograd` as a direct conda-forge dep.

**Conda release workflow** (`.github/workflows/conda-packaging.yml`):
- Strip the `v` from `GITHUB_REF_NAME` so the package version is `2.0.0.dev1`, not `v2.0.0.dev1`.
- Upload prereleases (`dev`/`rc`/`aN`/`bN`) under `-l dev` so they need `-c <channel>/label/dev` to install.

**Version**: bump `pyproject.toml` to `2.0.0.dev1` (canonical PEP 440 form). After merge, tag `v2.0.0.dev1` and re-run the release.