### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-merge-conflict
   - id: check-case-conflict
@@ -15,7 +15,7 @@ repos:
   - id: detect-private-key
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.2
+  rev: v0.15.12
   hooks:
     # - id: ruff
       # args: ["--fix"]
@@ -28,13 +28,13 @@ repos:
 #       args: [-vv, --fail-under=100, --omit-covered-files]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.2
   hooks:
   - id: codespell
     files: ^.*\.(py|rst|md)$
 
 - repo: https://github.com/DanielNoord/pydocstringformatter
-  rev: v0.7.3
+  rev: v0.7.5
   hooks:
     - id: pydocstringformatter
       args: [
@@ -44,13 +44,13 @@ repos:
       ]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.0
+  rev: v3.21.2
   hooks:
   - id: pyupgrade
-    args: [--py38-plus, --keep-runtime-typing]
+    args: [--py310-plus, --keep-runtime-typing]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.30.0
+  rev: 0.37.2
   hooks:
     - id: check-github-workflows
 

--- a/examples/TPMS/grading/cell_type.py
+++ b/examples/TPMS/grading/cell_type.py
@@ -10,7 +10,8 @@ between control points.
 
 from __future__ import annotations
 
-from typing import Callable, Tuple
+from typing import Tuple
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -19,7 +20,7 @@ import pyvista as pv
 from microgen import Tpms
 from microgen.shape.surface_functions import fischerKochS, gyroid, schwarzD, schwarzP
 
-ControlPoint = Tuple[float, float, float]
+ControlPoint = tuple[float, float, float]
 
 REPEAT = (4, 4, 2)
 TPMS_TYPES: dict[ControlPoint, Callable] = {

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import itertools
 import warnings
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
+from collections.abc import Iterator
 
 import gmsh
 import numpy as np

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import itertools
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -9,7 +9,8 @@ stored as :class:`microgen.cad.CadShape` and solids as raw OCCT
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -34,8 +35,7 @@ def _require_ocp() -> None:
         import OCP  # noqa: F401, PLC0415
     except ImportError as err:
         err_msg = (
-            "This Phase operation requires the CAD extra: "
-            "pip install 'microgen[cad]'"
+            "This Phase operation requires the CAD extra: pip install 'microgen[cad]'"
         )
         raise ImportError(err_msg) from err
 

--- a/microgen/rve.py
+++ b/microgen/rve.py
@@ -8,7 +8,8 @@ extra (``cadquery-ocp-novtk``).
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Sequence, Tuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -17,7 +18,7 @@ _DIM = 3
 if TYPE_CHECKING:
     from .cad import CadShape
 
-    Vector3DType = Tuple[float, float, float] | Sequence[float]
+    Vector3DType = tuple[float, float, float] | Sequence[float]
 
 
 class Rve:

--- a/microgen/shape/__init__.py
+++ b/microgen/shape/__init__.py
@@ -19,7 +19,8 @@ Shape (:mod:`microgen.shape`)
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Literal, Sequence, Tuple
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from . import implicit_ops, surface_functions
 from .box import Box
@@ -51,7 +52,7 @@ from .tpms import CylindricalTpms, Infill, SphericalTpms, Tpms
 from .tpms_grading import NormedDistance
 
 if TYPE_CHECKING:
-    Vector3DType = Tuple[float, float, float] | Sequence[float]
+    Vector3DType = tuple[float, float, float] | Sequence[float]
 
     TpmsPartType = Literal["sheet", "lower skeletal", "upper skeletal", "surface"]
 

--- a/microgen/shape/extruded_polygon.py
+++ b/microgen/shape/extruded_polygon.py
@@ -7,7 +7,8 @@ Extruded Polygon (:mod:`microgen.shape.extruded_polygon`)
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
+from collections.abc import Sequence
 
 import numpy as np
 import pyvista as pv

--- a/microgen/shape/implicit_ops.py
+++ b/microgen/shape/implicit_ops.py
@@ -311,8 +311,9 @@ def blend(
     fa, fb = a.require_func(), b.require_func()
     t = factor
     return _make_shape(
-        func=lambda x, y, z, _fa=fa, _fb=fb, _t=t: (1.0 - _t) * _fa(x, y, z)
-        + _t * _fb(x, y, z),
+        func=lambda x, y, z, _fa=fa, _fb=fb, _t=t: (
+            (1.0 - _t) * _fa(x, y, z) + _t * _fb(x, y, z)
+        ),
         bounds=_merge_bounds(a.bounds, b.bounds, "union"),
     )
 

--- a/microgen/shape/polyhedron.py
+++ b/microgen/shape/polyhedron.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pyvista as pv
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
     from microgen.cad import CadShape
     from microgen.shape import KwargsGenerateType, Vector3DType
 
-Vertex = Tuple[float, float, float]
-Face = Dict[str, List[int]]
+Vertex = tuple[float, float, float]
+Face = dict[str, list[int]]
 
 
 class Polyhedron(Shape):

--- a/microgen/shape/strut_lattice/face_centered_cubic.py
+++ b/microgen/shape/strut_lattice/face_centered_cubic.py
@@ -48,7 +48,7 @@ class FaceCenteredCubic(AbstractLattice):
 
         return np.array(cube_vertices + face_centers)
 
-    def _generate_face_center_to_cube_vertices_dict(self) -> dict[int, List[int]]:
+    def _generate_face_center_to_cube_vertices_dict(self) -> dict[int, list[int]]:
         """
         Dynamically generates a dictionary associating the indices of the face centers with the indices of the cube vertices.
         """

--- a/tests/shapes/test_lattice.py
+++ b/tests/shapes/test_lattice.py
@@ -86,9 +86,9 @@ def test_lattice_generate_vtk_periodic_must_produce_periodic_mesh() -> None:
     lattice = OctetTruss(strut_radius=0.05, cell_size=1.0)
     mesh = lattice.generate_vtk(size=0.1, periodic=True)
 
-    assert is_periodic(
-        mesh.points
-    ), "Mesh generated with periodic=True must be periodic"
+    assert is_periodic(mesh.points), (
+        "Mesh generated with periodic=True must be periodic"
+    )
 
 
 def test_lattice_generate_vtk_must_not_reuse_non_periodic_mesh_for_periodic_request() -> (

--- a/tests/shapes/test_tpms.py
+++ b/tests/shapes/test_tpms.py
@@ -808,6 +808,6 @@ def test_sweep_along_straight_line_is_finite_and_positive() -> None:
     tube_volume = np.pi * radial_max * radial_max * height
     v = abs(sheet.volume)
     assert v > 0.0, "Sweep produced an empty sheet"
-    assert (
-        v < tube_volume * 1.05
-    ), f"Sweep sheet volume {v:.2f} exceeds tube envelope {tube_volume:.2f}"
+    assert v < tube_volume * 1.05, (
+        f"Sweep sheet volume {v:.2f} exceeds tube envelope {tube_volume:.2f}"
+    )


### PR DESCRIPTION
## Summary

Run `pre-commit autoupdate` to bump all hook versions, and reformat the four files the newer ruff wanted to touch.

| Hook | From | To |
|---|---|---|
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| ruff-pre-commit | v0.8.2 | v0.15.12 |
| codespell | v2.3.0 | v2.4.2 |
| pydocstringformatter | v0.7.3 | v0.7.5 |
| pyupgrade | v3.19.0 | v3.21.2 |
| check-jsonschema | 0.30.0 | 0.37.2 |

The format reflows are limited to four files (`phase.py`, `implicit_ops.py`, `test_lattice.py`, `test_tpms.py`) — newer ruff prefers the `assert ..., (\n  msg\n)` style over the older `assert (\n  ...\n), msg`.

## Why now

The pinned ruff in pre-commit (v0.8.2, December 2024) and any developer running modern ruff locally produce different formatting, which made #128 fail CI on a style-only diff. Bumping pins keeps local and CI in sync.

## Test plan

- [x] `pre-commit run --all-files` passes locally on the new versions
- [ ] CI: `pre-commit/action@v3.0.1` job passes