### PR TITLE
Add F-rep implicit fields to primitive shapes

### DIFF
--- a/microgen/shape/box.py
+++ b/microgen/shape/box.py
@@ -7,9 +7,12 @@ Box (:mod:`microgen.shape.box`)
 
 from __future__ import annotations
 
+import itertools
 import warnings
 from typing import TYPE_CHECKING
 
+import numpy as np
+import numpy.typing as npt
 import pyvista as pv
 
 from microgen.operations import rotate
@@ -23,6 +26,13 @@ if TYPE_CHECKING:
 
 class Box(Shape):
     """Class to generate a box.
+
+    The implicit field is the canonical AABB SDF
+    (``max(|x|-hx, |y|-hy, |z|-hz)`` decomposed into outside/inside parts),
+    evaluated in the box's local frame so ``center`` and ``orientation``
+    transform the field correctly. Set on every instance so boxes compose
+    via ``|`` / ``&`` / ``-`` and stay usable without the ``[cad]`` extra
+    (only :meth:`generate` requires CAD).
 
     .. jupyter-execute::
        :hide-code:
@@ -58,6 +68,51 @@ class Box(Shape):
                 dim_z = dim[2]
             self.dim = (dim_x, dim_y, dim_z)
         self.dim = dim
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Box) -> None:
+        """Bake the box SDF and AABB onto ``_func`` / ``_bounds``."""
+        cx, cy, cz = (float(c) for c in self.center)
+        hx, hy, hz = (0.5 * float(d) for d in self.dim)
+        rot_inv = self.orientation.inv().as_matrix()
+
+        def _field(
+            x: npt.NDArray[np.float64],
+            y: npt.NDArray[np.float64],
+            z: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            # Transform world coords -> box-local coords.
+            px = x - cx
+            py = y - cy
+            pz = z - cz
+            lx = rot_inv[0, 0] * px + rot_inv[0, 1] * py + rot_inv[0, 2] * pz
+            ly = rot_inv[1, 0] * px + rot_inv[1, 1] * py + rot_inv[1, 2] * pz
+            lz = rot_inv[2, 0] * px + rot_inv[2, 1] * py + rot_inv[2, 2] * pz
+            qx = np.abs(lx) - hx
+            qy = np.abs(ly) - hy
+            qz = np.abs(lz) - hz
+            outside = np.sqrt(
+                np.maximum(qx, 0.0) ** 2
+                + np.maximum(qy, 0.0) ** 2
+                + np.maximum(qz, 0.0) ** 2,
+            )
+            inside = np.minimum(np.maximum(qx, np.maximum(qy, qz)), 0.0)
+            return outside + inside
+
+        # World-space AABB: take the 8 canonical-frame corners, rotate, recenter.
+        rot = self.orientation.as_matrix()
+        corners = np.array(list(itertools.product([-hx, hx], [-hy, hy], [-hz, hz])))
+        rotated = corners @ rot.T
+        margin = max(hx, hy, hz) * 0.1
+        self._func = _field
+        self._bounds = (
+            cx + float(rotated[:, 0].min()) - margin,
+            cx + float(rotated[:, 0].max()) + margin,
+            cy + float(rotated[:, 1].min()) - margin,
+            cy + float(rotated[:, 1].max()) + margin,
+            cz + float(rotated[:, 2].min()) - margin,
+            cz + float(rotated[:, 2].max()) + margin,
+        )
 
     def generate(self: Box, **_: KwargsGenerateType) -> CadShape:
         """Generate a box CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/microgen/shape/capsule.py
+++ b/microgen/shape/capsule.py
@@ -7,8 +7,11 @@ Capsule (:mod:`microgen.shape.capsule`)
 
 from __future__ import annotations
 
+import itertools
 from typing import TYPE_CHECKING
 
+import numpy as np
+import numpy.typing as npt
 import pyvista as pv
 
 from microgen.operations import rotate
@@ -22,6 +25,15 @@ if TYPE_CHECKING:
 
 class Capsule(Shape):
     """Class to generate a capsule (cylinder with hemispherical ends).
+
+    Canonical frame: capsule axis along ``+x``, segment from
+    ``(-height/2, 0, 0)`` to ``(+height/2, 0, 0)``, radius ``radius``.
+    The implicit field is the point-to-segment distance minus radius
+    (Inigo Quilez capsule SDF), evaluated in the local frame so
+    ``center`` and ``orientation`` transform the field correctly. Set on
+    every instance so capsules compose via ``|`` / ``&`` / ``-`` and
+    stay usable without the ``[cad]`` extra (only :meth:`generate`
+    requires CAD).
 
     .. jupyter-execute::
        :hide-code:
@@ -42,6 +54,47 @@ class Capsule(Shape):
         super().__init__(**kwargs)
         self.height = height
         self.radius = radius
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Capsule) -> None:
+        """Bake the capsule SDF and AABB onto ``_func`` / ``_bounds``."""
+        cx, cy, cz = (float(c) for c in self.center)
+        h = float(self.height)
+        r = float(self.radius)
+        half_h = 0.5 * h
+        rot_inv = self.orientation.inv().as_matrix()
+
+        def _field(
+            x: npt.NDArray[np.float64],
+            y: npt.NDArray[np.float64],
+            z: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            px = x - cx
+            py = y - cy
+            pz = z - cz
+            lx = rot_inv[0, 0] * px + rot_inv[0, 1] * py + rot_inv[0, 2] * pz
+            ly = rot_inv[1, 0] * px + rot_inv[1, 1] * py + rot_inv[1, 2] * pz
+            lz = rot_inv[2, 0] * px + rot_inv[2, 1] * py + rot_inv[2, 2] * pz
+            t = np.clip(lx, -half_h, half_h)
+            dx = lx - t
+            return np.sqrt(dx**2 + ly**2 + lz**2) - r
+
+        # World-space AABB: rotate the 8 corners of the canonical [(-h/2-r, h/2+r) x (-r, r) x (-r, r)] box.
+        rot = self.orientation.as_matrix()
+        corners = np.array(
+            list(itertools.product([-half_h - r, half_h + r], [-r, r], [-r, r])),
+        )
+        rotated = corners @ rot.T
+        margin = (half_h + r) * 0.1
+        self._func = _field
+        self._bounds = (
+            cx + float(rotated[:, 0].min()) - margin,
+            cx + float(rotated[:, 0].max()) + margin,
+            cy + float(rotated[:, 1].min()) - margin,
+            cy + float(rotated[:, 1].max()) + margin,
+            cz + float(rotated[:, 2].min()) - margin,
+            cz + float(rotated[:, 2].max()) + margin,
+        )
 
     def generate(self: Capsule, **_: KwargsGenerateType) -> CadShape:
         """Generate a capsule CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/microgen/shape/cylinder.py
+++ b/microgen/shape/cylinder.py
@@ -7,8 +7,11 @@ Cylinder (:mod:`microgen.shape.cylinder`)
 
 from __future__ import annotations
 
+import itertools
 from typing import TYPE_CHECKING
 
+import numpy as np
+import numpy.typing as npt
 import pyvista as pv
 
 from microgen.operations import rotate
@@ -22,6 +25,15 @@ if TYPE_CHECKING:
 
 class Cylinder(Shape):
     """Class to generate a cylinder.
+
+    Canonical frame: cylinder axis along ``+x`` from
+    ``(-height/2, 0, 0)`` to ``(+height/2, 0, 0)``, radius ``radius``.
+    The implicit field is a capped-cylinder SDF (radial + axial
+    distance composition), evaluated in the local frame so ``center``
+    and ``orientation`` transform the field correctly. Set on every
+    instance so cylinders compose via ``|`` / ``&`` / ``-`` and stay
+    usable without the ``[cad]`` extra (only :meth:`generate` requires
+    CAD).
 
     .. jupyter-execute::
        :hide-code:
@@ -42,6 +54,50 @@ class Cylinder(Shape):
         super().__init__(**kwargs)
         self.radius = radius
         self.height = height
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Cylinder) -> None:
+        """Bake the cylinder SDF and AABB onto ``_func`` / ``_bounds``."""
+        cx, cy, cz = (float(c) for c in self.center)
+        h = float(self.height)
+        r = float(self.radius)
+        half_h = 0.5 * h
+        rot_inv = self.orientation.inv().as_matrix()
+
+        def _field(
+            x: npt.NDArray[np.float64],
+            y: npt.NDArray[np.float64],
+            z: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            px = x - cx
+            py = y - cy
+            pz = z - cz
+            lx = rot_inv[0, 0] * px + rot_inv[0, 1] * py + rot_inv[0, 2] * pz
+            ly = rot_inv[1, 0] * px + rot_inv[1, 1] * py + rot_inv[1, 2] * pz
+            lz = rot_inv[2, 0] * px + rot_inv[2, 1] * py + rot_inv[2, 2] * pz
+            d_radial = np.sqrt(ly**2 + lz**2) - r
+            d_axial = np.abs(lx) - half_h
+            outside = np.sqrt(
+                np.maximum(d_radial, 0.0) ** 2 + np.maximum(d_axial, 0.0) ** 2,
+            )
+            inside = np.minimum(np.maximum(d_radial, d_axial), 0.0)
+            return outside + inside
+
+        rot = self.orientation.as_matrix()
+        corners = np.array(
+            list(itertools.product([-half_h, half_h], [-r, r], [-r, r])),
+        )
+        rotated = corners @ rot.T
+        margin = max(r, half_h) * 0.1
+        self._func = _field
+        self._bounds = (
+            cx + float(rotated[:, 0].min()) - margin,
+            cx + float(rotated[:, 0].max()) + margin,
+            cy + float(rotated[:, 1].min()) - margin,
+            cy + float(rotated[:, 1].max()) + margin,
+            cz + float(rotated[:, 2].min()) - margin,
+            cz + float(rotated[:, 2].max()) + margin,
+        )
 
     def generate(self: Cylinder, **_: KwargsGenerateType) -> CadShape:
         """Generate a cylinder CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/microgen/shape/ellipsoid.py
+++ b/microgen/shape/ellipsoid.py
@@ -7,10 +7,12 @@ Ellipsoid (:mod:`microgen.shape.ellipsoid`)
 
 from __future__ import annotations
 
+import itertools
 import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 import pyvista as pv
 
 from microgen.operations import rotate
@@ -24,6 +26,14 @@ if TYPE_CHECKING:
 
 class Ellipsoid(Shape):
     """Class to generate an ellipsoid.
+
+    The implicit field is the canonical ellipsoid scalar
+    ``sqrt((x/rx)^2 + (y/ry)^2 + (z/rz)^2) - 1`` (approximate SDF with
+    the correct zero-level set), evaluated in the local frame so
+    ``center`` and ``orientation`` transform the field correctly. Set
+    on every instance so ellipsoids compose via ``|`` / ``&`` / ``-``
+    and stay usable without the ``[cad]`` extra (only :meth:`generate`
+    requires CAD).
 
     .. jupyter-execute::
        :hide-code:
@@ -60,6 +70,40 @@ class Ellipsoid(Shape):
             radii = (a_x, a_y, a_z)
 
         self.radii = radii
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Ellipsoid) -> None:
+        """Bake the ellipsoid field and AABB onto ``_func`` / ``_bounds``."""
+        cx, cy, cz = (float(c) for c in self.center)
+        rx, ry, rz = (float(r) for r in self.radii)
+        rot_inv = self.orientation.inv().as_matrix()
+
+        def _field(
+            x: npt.NDArray[np.float64],
+            y: npt.NDArray[np.float64],
+            z: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            px = x - cx
+            py = y - cy
+            pz = z - cz
+            lx = rot_inv[0, 0] * px + rot_inv[0, 1] * py + rot_inv[0, 2] * pz
+            ly = rot_inv[1, 0] * px + rot_inv[1, 1] * py + rot_inv[1, 2] * pz
+            lz = rot_inv[2, 0] * px + rot_inv[2, 1] * py + rot_inv[2, 2] * pz
+            return np.sqrt((lx / rx) ** 2 + (ly / ry) ** 2 + (lz / rz) ** 2) - 1.0
+
+        rot = self.orientation.as_matrix()
+        corners = np.array(list(itertools.product([-rx, rx], [-ry, ry], [-rz, rz])))
+        rotated = corners @ rot.T
+        margin = max(rx, ry, rz) * 0.1
+        self._func = _field
+        self._bounds = (
+            cx + float(rotated[:, 0].min()) - margin,
+            cx + float(rotated[:, 0].max()) + margin,
+            cy + float(rotated[:, 1].min()) - margin,
+            cy + float(rotated[:, 1].max()) + margin,
+            cz + float(rotated[:, 2].min()) - margin,
+            cz + float(rotated[:, 2].max()) + margin,
+        )
 
     def generate(self: Ellipsoid, **_: KwargsGenerateType) -> CadShape:
         """Generate an ellipsoid CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/microgen/shape/sphere.py
+++ b/microgen/shape/sphere.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+import numpy.typing as npt
 import pyvista as pv
 
 from .shape import Shape
@@ -20,6 +22,11 @@ if TYPE_CHECKING:
 
 class Sphere(Shape):
     """Class to generate a sphere.
+
+    The implicit field ``f(p) = ||p - center|| - radius`` (a true SDF,
+    negative inside) is set on every instance so spheres compose with
+    other shapes through ``|`` / ``&`` / ``-`` and stay usable when the
+    ``[cad]`` extra is not installed (only :meth:`generate` requires CAD).
 
     .. jupyter-execute::
        :hide-code:
@@ -38,6 +45,30 @@ class Sphere(Shape):
         """Initialize the sphere."""
         super().__init__(**kwargs)
         self.radius = radius
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Sphere) -> None:
+        """Bake the sphere SDF and AABB onto ``_func`` / ``_bounds``."""
+        cx, cy, cz = (float(c) for c in self.center)
+        r = float(self.radius)
+        margin = r * 1.1
+
+        def _field(
+            x: npt.NDArray[np.float64],
+            y: npt.NDArray[np.float64],
+            z: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            return np.sqrt((x - cx) ** 2 + (y - cy) ** 2 + (z - cz) ** 2) - r
+
+        self._func = _field
+        self._bounds = (
+            cx - margin,
+            cx + margin,
+            cy - margin,
+            cy + margin,
+            cz - margin,
+            cz + margin,
+        )
 
     def generate(self: Sphere, **_: KwargsGenerateType) -> CadShape:
         """Generate a sphere CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/tests/shapes/test_primitive_implicit.py
+++ b/tests/shapes/test_primitive_implicit.py
@@ -1,0 +1,173 @@
+"""Tests for the implicit (F-rep) field set on primitive shape classes.
+
+Each primitive (`Box`, `Sphere`, `Cylinder`, `Capsule`, `Ellipsoid`) sets
+``_func`` and ``_bounds`` in ``__init__``. These tests verify the SDF sign
+inside / on / outside, AABB validity, and composability via the
+operators.
+"""
+
+# ruff: noqa: S101 assert https://docs.astral.sh/ruff/rules/assert/
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
+
+from microgen import Box, Capsule, Cylinder, Ellipsoid, Sphere
+
+
+def _eval_scalar(shape, point):
+    """Evaluate the implicit field at a single (x, y, z) point."""
+    x = np.array([point[0]], dtype=np.float64)
+    y = np.array([point[1]], dtype=np.float64)
+    z = np.array([point[2]], dtype=np.float64)
+    return float(shape.evaluate(x, y, z)[0])
+
+
+@pytest.mark.parametrize(
+    ("ctor", "kwargs", "inside_pt", "outside_pt", "surface_pt"),
+    [
+        # Sphere centered at origin, r=1
+        (Sphere, dict(radius=1.0), (0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (1.0, 0.0, 0.0)),
+        # Box (2, 1, 0.5) centered at origin
+        (
+            Box,
+            dict(dim=(2.0, 1.0, 0.5)),
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+        ),
+        # Cylinder along x, r=0.5, h=2
+        (
+            Cylinder,
+            dict(radius=0.5, height=2.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.5, 0.0),
+        ),
+        # Capsule along x, r=0.3, h=1
+        (
+            Capsule,
+            dict(radius=0.3, height=1.0),
+            (0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.3, 0.0),
+        ),
+        # Ellipsoid (1, 0.5, 0.25)
+        (
+            Ellipsoid,
+            dict(radii=(1.0, 0.5, 0.25)),
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+        ),
+    ],
+)
+def test_field_sign(ctor, kwargs, inside_pt, outside_pt, surface_pt):
+    """Inside negative, outside positive, surface ~= 0."""
+    s = ctor(**kwargs)
+    assert _eval_scalar(s, inside_pt) < 0.0
+    assert _eval_scalar(s, outside_pt) > 0.0
+    assert abs(_eval_scalar(s, surface_pt)) < 1e-9
+
+
+@pytest.mark.parametrize(
+    ("ctor", "kwargs"),
+    [
+        (Sphere, dict(radius=1.0)),
+        (Box, dict(dim=(2.0, 1.0, 0.5))),
+        (Cylinder, dict(radius=0.5, height=2.0)),
+        (Capsule, dict(radius=0.3, height=1.0)),
+        (Ellipsoid, dict(radii=(1.0, 0.5, 0.25))),
+    ],
+)
+def test_aabb_contains_zero_set(ctor, kwargs):
+    """Bounds must enclose the field's zero level set."""
+    s = ctor(**kwargs)
+    xmin, xmax, ymin, ymax, zmin, zmax = s.bounds
+    # corners of the AABB are outside (field > 0); the center is inside (< 0)
+    cx, cy, cz = (
+        0.5 * (xmin + xmax),
+        0.5 * (ymin + ymax),
+        0.5 * (zmin + zmax),
+    )
+    assert _eval_scalar(s, (cx, cy, cz)) < 0.0
+    for corner in [
+        (xmin, ymin, zmin),
+        (xmax, ymax, zmax),
+        (xmin, ymax, zmin),
+        (xmax, ymin, zmax),
+    ]:
+        assert _eval_scalar(s, corner) > 0.0
+
+
+@pytest.mark.parametrize(
+    ("ctor", "kwargs"),
+    [
+        (Sphere, dict(radius=1.0)),
+        (Box, dict(dim=(2.0, 1.0, 0.5))),
+        (Cylinder, dict(radius=0.5, height=2.0)),
+        (Capsule, dict(radius=0.3, height=1.0)),
+        (Ellipsoid, dict(radii=(1.0, 0.5, 0.25))),
+    ],
+)
+def test_center_offset_translates_field(ctor, kwargs):
+    """A non-zero ``center`` should translate the inside region accordingly."""
+    offset = (3.0, -1.0, 2.0)
+    s_origin = ctor(**kwargs)
+    s_offset = ctor(**kwargs, center=offset)
+    # The offset center is inside; the original origin is outside the offset shape.
+    assert _eval_scalar(s_offset, offset) == pytest.approx(
+        _eval_scalar(s_origin, (0.0, 0.0, 0.0)),
+    )
+    assert _eval_scalar(s_offset, (0.0, 0.0, 0.0)) > 0.0
+
+
+def test_orientation_rotates_box_field():
+    """Rotating a Box 90° about z swaps its x and y extents."""
+    box = Box(dim=(2.0, 0.5, 0.5))
+    rotated = Box(
+        dim=(2.0, 0.5, 0.5),
+        orientation=Rotation.from_euler("z", 90, degrees=True),
+    )
+    # Point along +y at distance 0.9 is outside the un-rotated box, inside the rotated one.
+    assert _eval_scalar(box, (0.0, 0.9, 0.0)) > 0.0
+    assert _eval_scalar(rotated, (0.0, 0.9, 0.0)) < 0.0
+
+
+def test_union_field_is_min():
+    """``a | b`` evaluates to ``min(f_a, f_b)`` pointwise."""
+    a = Sphere(radius=0.5, center=(-0.6, 0.0, 0.0))
+    b = Sphere(radius=0.5, center=(0.6, 0.0, 0.0))
+    union = a | b
+    # Each sphere's center is inside the union.
+    assert _eval_scalar(union, (-0.6, 0.0, 0.0)) < 0.0
+    assert _eval_scalar(union, (0.6, 0.0, 0.0)) < 0.0
+    # The midpoint between them is outside both individual spheres
+    # (radius 0.5, distance 0.6) and so outside the union.
+    assert _eval_scalar(union, (0.0, 0.0, 0.0)) > 0.0
+
+
+def test_intersection_field_is_max():
+    """``a & b`` evaluates to ``max(f_a, f_b)`` pointwise."""
+    sph = Sphere(radius=1.0)
+    box = Box(dim=(1.0, 1.0, 1.0))
+    inter = sph & box
+    # Origin is inside both, so inside the intersection.
+    assert _eval_scalar(inter, (0.0, 0.0, 0.0)) < 0.0
+    # Point at (0.7, 0.0, 0.0) is inside the sphere but outside the box.
+    assert _eval_scalar(sph, (0.7, 0.0, 0.0)) < 0.0
+    assert _eval_scalar(box, (0.7, 0.0, 0.0)) > 0.0
+    assert _eval_scalar(inter, (0.7, 0.0, 0.0)) > 0.0
+
+
+def test_difference_field_carves_out_b():
+    """``a - b`` removes b's interior from a."""
+    sph = Sphere(radius=1.0)
+    hole = Sphere(radius=0.3, center=(0.5, 0.0, 0.0))
+    diff = sph - hole
+    # Point at hole center: inside sph, inside hole → carved out.
+    assert _eval_scalar(diff, (0.5, 0.0, 0.0)) > 0.0
+    # Point at sphere center: inside sph, outside hole → kept.
+    assert _eval_scalar(diff, (0.0, 0.0, 0.0)) < 0.0


### PR DESCRIPTION
  Box, Sphere, Cylinder, Capsule, Ellipsoid each set _func / _bounds in
  __init__ via a per-class _setup_frep_field. SDF formulas verbatim from
  PR #116 (fast O(1) closures, no autograd), with center and orientation
  baked directly into the field. CAD generate() and pyvista generate_vtk()
  overrides untouched — only :meth:`generate` requires the [cad] extra.

  Operators |, &, -, ~ now compose primitives directly: `Sphere(...) &
  Box(...)` returns a Shape with a composed implicit field, no CAD or
  to_implicit() conversion required.

  Tests in tests/shapes/test_primitive_implicit.py: SDF sign at center /
  surface / outside, AABB validity, center translation, orientation,
  composability.