### PR TITLE
Enforce FBT001/FBT002 and N802 ruff rules

### DIFF
--- a/microgen/shape/strut_lattice/abstract_lattice.py
+++ b/microgen/shape/strut_lattice/abstract_lattice.py
@@ -46,6 +46,7 @@ class AbstractLattice(Shape):
         strut_heights: float | list[float] | None = None,
         base_vertices: npt.NDArray[np.float64] | None = None,
         strut_vertex_pairs: npt.NDArray[np.int64] | None = None,
+        *,
         cell_size: float = 1.0,
         strut_joints: bool = False,
         density: float | None = None,

--- a/microgen/shape/strut_lattice/custom_lattice.py
+++ b/microgen/shape/strut_lattice/custom_lattice.py
@@ -21,10 +21,11 @@ class CustomLattice(AbstractLattice):
     Uses user-defined base vertices and strut vertex pairs.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         base_vertices: npt.NDArray[np.float64],
         strut_vertex_pairs: npt.NDArray[np.int64],
+        *,
         strut_radius: float | None = None,
         strut_heights: float | list[float] | None = None,
         cell_size: float = 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,13 @@ ignore_missing_imports = true
 target-version = "py310"
 
 [tool.ruff.lint]
+extend-select = [
+    # Boolean traps — booleans in public APIs must be keyword-only.
+    "FBT001",
+    "FBT002",
+    # Function names must be lowercase.
+    "N802",
+]
 exclude = [
     "docs/*",
     "tests/*",


### PR DESCRIPTION
## Summary

Locks in ruff enforcement of the boolean-trap rules (FBT001/FBT002) and lowercase-function-name rule (N802).  N802 was already satisfied by #134; this PR adds it to ``extend-select`` so future violations fail CI.  FBT requires two ``*`` insertions to mark booleans as kw-only.

## Changes

- `pyproject.toml` — `extend-select = ["FBT001", "FBT002", "N802"]`
- `microgen/shape/strut_lattice/abstract_lattice.py` — `*` before `cell_size` / `strut_joints` / `density` in `AbstractLattice.__init__`
- `microgen/shape/strut_lattice/custom_lattice.py` — `*` before strut-related kwargs in `CustomLattice.__init__`; stale `# noqa: PLR0913` removed