### PR TITLE
Allow polymorphic surface sampling; cleanup exports

### DIFF
--- a/microgen/__init__.py
+++ b/microgen/__init__.py
@@ -17,7 +17,6 @@ from .operations import (
     rescale,
     rotate,
     rotate_euler,
-    rotate_pv_euler,
 )
 from .periodic import periodic_split_and_translate
 from .phase import Phase
@@ -37,6 +36,7 @@ from .shape import (
     Ellipsoid,
     ExtrudedPolygon,
     FaceCenteredCubic,
+    GradedInfill,
     Infill,
     NormedDistance,
     Octahedron,
@@ -48,6 +48,7 @@ from .shape import (
     Sphere,
     SphericalTpms,
     Spinodoid,
+    Sweep,
     Tpms,
     TruncatedCube,
     TruncatedCuboctahedron,
@@ -76,6 +77,7 @@ __all__ = [
     "Ellipsoid",
     "ExtrudedPolygon",
     "FaceCenteredCubic",
+    "GradedInfill",
     "Infill",
     "NonBoxMeshError",
     "NormedDistance",
@@ -91,6 +93,7 @@ __all__ = [
     "Shape",
     "Sphere",
     "Spinodoid",
+    "Sweep",
     "Tpms",
     "TruncatedCube",
     "TruncatedCuboctahedron",
@@ -117,7 +120,6 @@ __all__ = [
     "rescale",
     "rotate",
     "rotate_euler",
-    "rotate_pv_euler",
     "Report",
     "SingleMesh",
     "surface_functions",

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -126,39 +126,6 @@ def rotate_euler(
     return rotate(obj, center, rotation)
 
 
-def rotate_pv_euler(
-    obj: pv.PolyData,
-    center: Sequence[float],
-    angles_or_rotation: Sequence[float] | Rotation,
-) -> pv.PolyData:
-    """Rotate object according to ZXZ Euler angle convention.
-
-    :param obj: Object to rotate
-    :param center: numpy array (x, y, z)
-    :param angles_or_rotation: list of Euler angles (psi, theta, phi) in
-        degrees, or a scipy ``Rotation`` object
-
-    :return: Rotated object
-    """
-    if isinstance(angles_or_rotation, Rotation):
-        rotation = angles_or_rotation
-    else:
-        rotation = Rotation.from_euler("ZXZ", angles_or_rotation, degrees=True)
-
-    rotvec = rotation.as_rotvec(degrees=True)
-    angle = np.linalg.norm(rotvec)
-    if angle == 0:
-        return obj
-    axis = rotvec / angle
-
-    return obj.rotate_vector(
-        vector=axis,
-        angle=angle,
-        point=tuple(center),
-        inplace=False,
-    )
-
-
 def rescale(shape: CadShape, scale: float | tuple[float, float, float]) -> CadShape:
     """Rescale given object according to scale parameters [dim_x, dim_y, dim_z]."""
     from .phase import Phase  # noqa: PLC0415

--- a/microgen/rve.py
+++ b/microgen/rve.py
@@ -59,9 +59,6 @@ class Rve:
         self.min_point = self.center - 0.5 * self.dim
         self.max_point = self.center + 0.5 * self.dim
 
-        self.is_matrix = False
-        self.matrix_number = 0
-
         self._cached_box: CadShape | None = None
 
     @property

--- a/microgen/shape/__init__.py
+++ b/microgen/shape/__init__.py
@@ -48,7 +48,7 @@ from .strut_lattice import (
     TruncatedOctahedron,
 )
 from .spinodoid import Spinodoid
-from .tpms import CylindricalTpms, Infill, SphericalTpms, Tpms
+from .tpms import CylindricalTpms, GradedInfill, Infill, SphericalTpms, Sweep, Tpms
 from .tpms_grading import NormedDistance
 
 if TYPE_CHECKING:
@@ -162,6 +162,7 @@ __all__ = [
     "Ellipsoid",
     "ExtrudedPolygon",
     "FaceCenteredCubic",
+    "GradedInfill",
     "Infill",
     "NormedDistance",
     "Octahedron",
@@ -173,6 +174,7 @@ __all__ = [
     "Sphere",
     "SphericalTpms",
     "Spinodoid",
+    "Sweep",
     "Tpms",
     "TruncatedCube",
     "TruncatedCuboctahedron",

--- a/microgen/shape/box.py
+++ b/microgen/shape/box.py
@@ -21,6 +21,7 @@ from .shape import Shape
 if TYPE_CHECKING:
     from microgen.cad import CadShape
     from microgen.shape import KwargsGenerateType, Vector3DType
+    from microgen.shape.shape import BoundsType
 
 
 class Box(Shape):
@@ -105,10 +106,24 @@ class Box(Shape):
 
     def generate_surface_mesh(
         self: Box,
+        bounds: BoundsType | None = None,
+        resolution: int | None = None,
         level: int = 0,
         **_: KwargsGenerateType,
     ) -> pv.PolyData:
-        """Generate a box VTK shape using the given parameters."""
+        """Generate a box VTK shape using the given parameters.
+
+        When ``bounds`` or ``resolution`` is explicitly provided, fall back to
+        the implicit (marching-cubes-on-SDF) base implementation so polymorphic
+        callers that ask for a specific sampling get what they asked for.
+        Otherwise the native :class:`pyvista.Box` (fixed 6-face quad mesh
+        controlled by ``level``) is used.
+        """
+        if bounds is not None or resolution is not None:
+            return super().generate_surface_mesh(
+                bounds=bounds,
+                resolution=resolution if resolution is not None else 50,
+            )
         box = pv.Box(
             bounds=(
                 self.center[0] - 0.5 * self.dim[0],

--- a/microgen/shape/sphere.py
+++ b/microgen/shape/sphere.py
@@ -18,6 +18,7 @@ from .shape import Shape
 if TYPE_CHECKING:
     from microgen.cad import CadShape
     from microgen.shape import KwargsGenerateType, Vector3DType
+    from microgen.shape.shape import BoundsType
 
 
 class Sphere(Shape):
@@ -78,11 +79,25 @@ class Sphere(Shape):
 
     def generate_surface_mesh(
         self: Sphere,
+        bounds: BoundsType | None = None,
+        resolution: int | None = None,
         theta_resolution: int = 50,
         phi_resolution: int = 50,
         **_: KwargsGenerateType,
     ) -> pv.PolyData:
-        """Generate a sphere VTK shape using the given parameters."""
+        """Generate a sphere VTK shape using the given parameters.
+
+        When ``bounds`` or ``resolution`` is explicitly provided, fall back to
+        the implicit (marching-cubes-on-SDF) base implementation so polymorphic
+        callers that ask for a specific sampling get what they asked for.
+        Otherwise the native :class:`pyvista.Sphere` (parametric, controlled
+        by ``theta_resolution``/``phi_resolution``) is used.
+        """
+        if bounds is not None or resolution is not None:
+            return super().generate_surface_mesh(
+                bounds=bounds,
+                resolution=resolution if resolution is not None else 50,
+            )
         return pv.Sphere(
             radius=self.radius,
             center=tuple(self.center),

--- a/microgen/shape/spinodoid.py
+++ b/microgen/shape/spinodoid.py
@@ -34,6 +34,7 @@ from .shape import Shape
 if TYPE_CHECKING:
     from microgen.cad import CadShape
     from microgen.shape import KwargsGenerateType, Vector3DType
+    from microgen.shape.shape import BoundsType
 
 
 class Spinodoid(Shape):
@@ -215,9 +216,23 @@ class Spinodoid(Shape):
 
     def generate_surface_mesh(
         self: Spinodoid,
+        bounds: BoundsType | None = None,
+        resolution: int | None = None,
         **_: KwargsGenerateType,
     ) -> pv.PolyData:
-        """Generate the iso-surface as a PolyData with center+rotation applied."""
+        """Generate the iso-surface as a PolyData with center+rotation applied.
+
+        The native path uses the cached structured-grid surface whose resolution
+        is fixed at construction time (``Spinodoid(resolution=…)``). When
+        ``bounds`` or ``resolution`` is explicitly provided here, fall back to
+        the implicit (marching-cubes-on-SDF) base implementation so polymorphic
+        callers can re-sample the field at an arbitrary resolution / bbox.
+        """
+        if bounds is not None or resolution is not None:
+            return super().generate_surface_mesh(
+                bounds=bounds,
+                resolution=resolution if resolution is not None else 50,
+            )
         polydata = self.surface.copy()
         polydata = rotate(polydata, center=(0, 0, 0), rotation=self.orientation)
         return polydata.translate(xyz=self.center)

--- a/tests/test_no_top_level_ocp_imports.py
+++ b/tests/test_no_top_level_ocp_imports.py
@@ -1,0 +1,88 @@
+"""Lint-style test: no top-level OCP imports outside the CAD boundary.
+
+The ``[cad]`` extra (``cadquery-ocp-novtk``) is strictly optional.  ``import
+microgen`` must succeed without it, which means no module reachable from
+``microgen.__init__`` may execute ``import OCP`` / ``from OCP …`` at
+module-load time.  Every OCP import must be either:
+
+  * inside a function/method body (lazy);
+  * guarded by ``if TYPE_CHECKING:`` (only consumed by type checkers); or
+  * located inside the CAD boundary (``microgen/cad.py`` today; the
+    ``microgen/cad/`` subpackage after PR 4).
+
+This test walks every ``.py`` under ``microgen/`` and AST-checks the
+top level for stray OCP imports.  Failing here is what catches a future
+refactor that accidentally drops an eager ``from OCP.… import …`` at
+module scope and silently breaks ``pip install microgen`` (no extras).
+"""
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+MICROGEN_ROOT = Path(__file__).resolve().parent.parent / "microgen"
+
+# Files allowed to have top-level OCP imports (the CAD boundary).  Paths are
+# relative to ``microgen/``.  Extend this list as the CAD subpackage grows
+# (PR 4 splits ``cad.py`` into a ``cad/`` subpackage).
+_CAD_BOUNDARY = {
+    "cad.py",
+}
+
+
+def _is_type_checking_block(node: ast.stmt) -> bool:
+    """True if ``node`` is ``if TYPE_CHECKING:`` (any common spelling)."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    if (
+        isinstance(test, ast.Attribute)
+        and isinstance(test.value, ast.Name)
+        and test.value.id == "typing"
+        and test.attr == "TYPE_CHECKING"
+    ):
+        return True
+    return False
+
+
+def _top_level_imports(tree: ast.Module) -> list[ast.stmt]:
+    """Return module-level import statements, skipping ``if TYPE_CHECKING:``."""
+    out: list[ast.stmt] = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            out.append(node)
+        elif _is_type_checking_block(node):
+            # Skip — these imports never execute at runtime.
+            continue
+    return out
+
+
+def _imports_ocp(node: ast.stmt) -> bool:
+    if isinstance(node, ast.ImportFrom):
+        return (node.module or "").split(".", 1)[0] == "OCP"
+    if isinstance(node, ast.Import):
+        return any(alias.name.split(".", 1)[0] == "OCP" for alias in node.names)
+    return False
+
+
+def test_no_top_level_ocp_imports_outside_cad_boundary() -> None:
+    """Walk microgen/*.py and assert no eager OCP import escapes the CAD boundary."""
+    offenders: list[str] = []
+    for py in MICROGEN_ROOT.rglob("*.py"):
+        rel = py.relative_to(MICROGEN_ROOT).as_posix()
+        if rel in _CAD_BOUNDARY:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in _top_level_imports(tree):
+            if _imports_ocp(node):
+                offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        "Top-level OCP imports outside the CAD boundary "
+        f"({sorted(_CAD_BOUNDARY)}): {offenders}. "
+        "Move them inside a function body or under "
+        "``if TYPE_CHECKING:``."
+    )


### PR DESCRIPTION
Make Shape.generate_surface_mesh polymorphic for Box, Sphere and Spinodoid by accepting optional bounds/resolution and falling back to the SDF/marching-cubes path when callers request explicit sampling. Add BoundsType imports and update docstrings to explain the behavior. Remove the legacy rotate_pv_euler function and its export from operations/__init__ (cleanup of Euler helper). Tidy Rve by removing unused is_matrix/matrix_number defaults. Expose new TPMS-related classes (GradedInfill, Sweep) in shape exports and update __all__ accordingly. Add a lint test (tests/test_no_top_level_ocp_imports.py) to prevent top-level OCP imports outside the CAD boundary.