### PR TITLE
Refactor/phase

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -311,7 +311,7 @@ Raster a phase to create a periodic pattern:
        radii=(0.15, 0.1, 0.08)
    )
    ellipsoid_cad = ellipsoid.generate_cad()
-   phase = microgen.Phase(shape=ellipsoid_cad)
+   phase = microgen.Phase.from_cad(ellipsoid_cad)
 
    # Define RVE
    rve = microgen.Rve(dim=(0.5, 0.5, 0.5))
@@ -325,7 +325,7 @@ Raster a phase to create a periodic pattern:
 
    # Compose a compound from all rastered solids and export to STL
    compound = make_compound_from_solids(
-       solid for p in rastered for solid in p.solids
+       solid.wrapped for p in rastered for solid in p.cad.solids()
    )
    compound.export_stl("rastered.stl")
 
@@ -384,7 +384,7 @@ Generate a periodic mesh suitable for homogenization:
    shape = gyroid.generate_cad(type_part='sheet')
 
    # Create a phase from the shape
-   phase = microgen.Phase(shape=shape)
+   phase = microgen.Phase.from_cad(shape)
 
    # Export to STEP file first
    shape.export_step('gyroid.step')

--- a/examples/3Doperations/rasterEllipsoid/rasterEllipsoid.py
+++ b/examples/3Doperations/rasterEllipsoid/rasterEllipsoid.py
@@ -8,10 +8,10 @@ rve = Rve(dim=1)
 elem = Ellipsoid(radii=(0.15, 0.31, 0.4))
 elli = elem.generate_cad()
 
-raster = raster_phase(phase=Phase(shape=elli), rve=rve, grid=[5, 5, 5])
+raster = raster_phase(phase=Phase.from_cad(elli), rve=rve, grid=[5, 5, 5])
 
 compound = make_compound_from_solids(
-    [solid for phase in raster for solid in phase.solids]
+    [solid.wrapped for phase in raster for solid in phase.cad.solids()]
 )
 step_file = str(Path(__file__).parent / "compound.step")
 compound.export_step(step_file)

--- a/examples/3Doperations/voronoi/voronoi.py
+++ b/examples/3Doperations/voronoi/voronoi.py
@@ -39,7 +39,7 @@ compound = make_compound(shapes)
 step_file = str(Path(__file__).parent / "compound.step")
 compound.export_step(step_file)
 
-phases = [Phase(shape=shape) for shape in shapes]
+phases = [Phase.from_cad(shape) for shape in shapes]
 
 vtk_file = str(Path(__file__).parent / "Voronoi.vtk")
 mesh(

--- a/examples/3Doperations/voronoiGyroid/voronoiGyroid.py
+++ b/examples/3Doperations/voronoiGyroid/voronoiGyroid.py
@@ -18,9 +18,9 @@ gyroid = gyroid.generate_cad(type_part="sheet").translate((0.5, 0.5, 0.5))
 phases = []
 for polyhedron in polyhedra:
     shape = polyhedron.generate_cad()
-    phases.append(Phase(shape=shape.intersect(gyroid)))
+    phases.append(Phase.from_cad(shape.intersect(gyroid)))
 
-compound = make_compound([phase.shape for phase in phases])
+compound = make_compound([phase.cad for phase in phases])
 step_file = str(Path(__file__).parent / "compound.step")
 compound.export_step(step_file)
 

--- a/examples/Lattices/honeycomb/honeycomb.py
+++ b/examples/Lattices/honeycomb/honeycomb.py
@@ -38,14 +38,14 @@ for seed in seedList:
     )
     shapeList.append(poly.generate_cad())
 
-boxPhase = Phase(shape=box.generate_cad())
+boxPhase = Phase.from_cad(box.generate_cad())
 
 honeycomb = cut_phase_by_shape_list(phase_to_cut=boxPhase, shapes=shapeList)
 
 step_file = str(Path(__file__).parent / "honeycomb.step")
 stl_file = str(Path(__file__).parent / "honeycomb.stl")
-honeycomb.shape.export_step(step_file)
-honeycomb.shape.export_stl(stl_file)
+honeycomb.cad.export_step(step_file)
+honeycomb.cad.export_stl(stl_file)
 vtk_file = str(Path(__file__).parent / "honeycomb.vtk")
 mesh(
     mesh_file=step_file,

--- a/examples/Lattices/octetTruss/octetTruss.py
+++ b/examples/Lattices/octetTruss/octetTruss.py
@@ -71,14 +71,14 @@ for i in range(0, n):
         height=height[i],
         radius=radius[i],
     )
-    list_phases.append(Phase(shape=elem.generate_cad()))
+    list_phases.append(Phase.from_cad(elem.generate_cad()))
 
 for phase_elem in list_phases:
     periodicPhase = periodic_split_and_translate(phase=phase_elem, rve=rve)
     listPeriodicPhases.append(periodicPhase)
 
 phases_cut = cut_phases(phases=listPeriodicPhases, reverse_order=False)
-compound = make_compound([phase.shape for phase in phases_cut])
+compound = make_compound([phase.cad for phase in phases_cut])
 
 step_file = str(Path(__file__).parent / "octettruss.step")
 stl_file = str(Path(__file__).parent / "octettruss.stl")

--- a/examples/Mesh/gyroid/gyroid_step_remesh.py
+++ b/examples/Mesh/gyroid/gyroid_step_remesh.py
@@ -35,12 +35,12 @@ geometry = Tpms(
 
 # 2. Wrap the geometry into a microgen Phase object.
 phases = []
-phases.append(Phase(shape=geometry.generate_cad()))
+phases.append(Phase.from_cad(geometry.generate_cad()))
 rve = Rve(dim=1)
 
 # 3. Export the geometry as a STEP file.
 step_file = str(Path(__file__).parent / "gyroid.step")
-phases[0].shape.export_step(step_file)
+phases[0].cad.export_step(step_file)
 
 # 4. Import the STEP file and create a mesh with periodic constraints and export as VTK.
 

--- a/microgen/mesh.py
+++ b/microgen/mesh.py
@@ -219,18 +219,27 @@ def is_periodic(
     return True
 
 
+def _phase_solid_count(phase: Phase) -> int:
+    """Number of TopoDS_Solid in a phase's CAD representation.
+
+    Always materialises (and caches) the CAD view — required because
+    gmsh allocates entity tags per OCCT solid.
+    """
+    return len(phase.cad.solids())
+
+
 def _generate_list_tags(list_phases: list[Phase]) -> list[list[int]]:
     list_tags: list[list[int]] = []
     start: int = 1
     for phase in list_phases:
-        stop = start + len(phase.solids)
+        stop = start + _phase_solid_count(phase)
         list_tags.append(list(range(start, stop)))
         start = stop
     return list_tags
 
 
 def _generate_list_dim_tags(list_phases: list[Phase]) -> list[tuple[int, int]]:
-    nb_tags = sum(len(phase.solids) for phase in list_phases)
+    nb_tags = sum(_phase_solid_count(phase) for phase in list_phases)
     return [(_DIM_COUNT, tag) for tag in range(1, nb_tags + 1)]
 
 

--- a/microgen/operations.py
+++ b/microgen/operations.py
@@ -127,10 +127,31 @@ def rotate_euler(
 
 
 def rescale(shape: CadShape, scale: float | tuple[float, float, float]) -> CadShape:
-    """Rescale given object according to scale parameters [dim_x, dim_y, dim_z]."""
-    from .phase import Phase  # noqa: PLC0415
+    """Rescale ``shape`` by ``scale = (sx, sy, sz)`` (or a scalar) about its centroid.
 
-    return Phase.rescale_shape(shape, scale)
+    Preserves the shape's center of mass — scaling is performed about it.
+    """
+    require_cad()
+    from .cad import transform_geometry  # noqa: PLC0415
+
+    if isinstance(scale, (int, float)):
+        sx = sy = sz = float(scale)
+    else:
+        sx, sy, sz = (float(s) for s in scale)
+
+    center = shape.center()
+    cx, cy, cz = center.x, center.y, center.z
+
+    # translate(-c) → scale about origin → translate(+c), as a single 3x4 affine
+    matrix = np.array(
+        [
+            [sx, 0.0, 0.0, cx - sx * cx],
+            [0.0, sy, 0.0, cy - sy * cy],
+            [0.0, 0.0, sz, cz - sz * cz],
+        ],
+        dtype=np.float64,
+    )
+    return transform_geometry(shape, matrix)
 
 
 def _unify_solids(shape: TopoDS_Shape) -> CadShape:
@@ -177,7 +198,7 @@ def fuse_shapes(shapes: list[CadShape], *, retain_edges: bool) -> CadShape:
 def cut_phases_by_shape(phases: list[Phase], cut_obj: CadShape) -> list[Phase]:
     """Cut list of phases by a given shape.
 
-    :param phases: list of phases to cut
+    :param phases: list of phases (must be CAD-backed)
     :param cut_obj: cutting object
 
     :return phase_cut: final result
@@ -190,18 +211,18 @@ def cut_phases_by_shape(phases: list[Phase], cut_obj: CadShape) -> list[Phase]:
     phase_cut: list[Phase] = []
 
     for phase in phases:
-        if phase.shape is None:
+        if phase.is_empty:
             continue
-        cut = CadShape(BRepAlgoAPI_Cut(phase.shape.wrapped, cut_obj.wrapped).Shape())
+        cut = CadShape(BRepAlgoAPI_Cut(phase.cad.wrapped, cut_obj.wrapped).Shape())
         if len(cut.solids()) > 0:
-            phase_cut.append(Phase(shape=cut))
+            phase_cut.append(Phase.from_cad(cut))
     return phase_cut
 
 
 def cut_phase_by_shape_list(phase_to_cut: Phase, shapes: list[CadShape]) -> Phase:
     """Cut a phase by a list of shapes.
 
-    :param phase_to_cut: phase to cut
+    :param phase_to_cut: phase to cut (must be CAD-backed)
     :param shapes: list of cutting shapes
 
     :return resultCut: cut phase
@@ -211,13 +232,13 @@ def cut_phase_by_shape_list(phase_to_cut: Phase, shapes: list[CadShape]) -> Phas
 
     from .phase import Phase  # noqa: PLC0415
 
-    result = phase_to_cut.shape
-    if result is None:
-        err_msg = "phase_to_cut has no shape to cut"
+    if phase_to_cut.is_empty:
+        err_msg = "phase_to_cut is empty"
         raise ValueError(err_msg)
+    result = phase_to_cut.cad
     for shape in shapes:
         result = CadShape(BRepAlgoAPI_Cut(result.wrapped, shape.wrapped).Shape())
-    return Phase(shape=result)
+    return Phase.from_cad(result)
 
 
 def cut_shapes(shapes: list[CadShape], *, reverse_order: bool = True) -> list[CadShape]:
@@ -253,20 +274,48 @@ def cut_shapes(shapes: list[CadShape], *, reverse_order: bool = True) -> list[Ca
 
 
 def cut_phases(phases: list[Phase], *, reverse_order: bool = True) -> list[Phase]:
-    """Cut list of shapes in the given order (or reverse) and fuse them.
+    """Cut list of phases in the given order (or reverse) and fuse them.
 
-    :param phases: list of phases to cut
-    :param reverse_order: bool, order for cutting shapes, \
-        when True: the last shape of the list is not cut
+    :param phases: list of phases to cut (each must be CAD-backed)
+    :param reverse_order: order for cutting shapes;
+        when ``True``, the last shape of the list is not cut
 
-    :return list of phases
+    :return: list of phases
     """
     from .phase import Phase  # noqa: PLC0415
 
-    shapes = [phase.shape for phase in phases]
+    shapes = [phase.cad for phase in phases]
     cutted_shapes = cut_shapes(shapes, reverse_order=reverse_order)
 
-    return [Phase(shape=shape) for shape in cutted_shapes]
+    return [Phase.from_cad(shape) for shape in cutted_shapes]
+
+
+def _split_cad_in_grid(
+    cad: CadShape,
+    rve: Rve,
+    grid: list[int],
+) -> list[TopoDS_Shape]:
+    """Split a CAD shape into solids per (grid-1)^3 interior cell planes."""
+    require_cad()
+    from .cad import enumerate_solids, make_plane_face, split_shape  # noqa: PLC0415
+
+    result: list[TopoDS_Shape] = []
+    for solid in enumerate_solids(cad):
+        current = CadShape(solid)
+        for axis in range(3):
+            direction = tuple(int(axis == i) for i in range(3))
+            coords = np.linspace(
+                start=rve.min_point[axis],
+                stop=rve.max_point[axis],
+                num=grid[axis],
+                endpoint=False,
+            )[1:]
+            for pos in coords:
+                base_pnt = tuple(float(pos) * direction[k] for k in range(3))
+                plane = make_plane_face(base_pnt, direction)
+                current = split_shape(current, plane)
+        result.extend(enumerate_solids(current))
+    return result
 
 
 def raster_phase(
@@ -276,22 +325,51 @@ def raster_phase(
     *,
     phase_per_raster: bool = True,
 ) -> Phase | list[Phase]:
-    """Raster solids from phase according to the rve divided by the given grid.
+    """Raster a phase according to the RVE divided by the given grid.
 
-    :param phase: phase to raster
+    Each solid in the phase is split by the (grid-1) interior planes per
+    axis (CAD-backed phases only).  When ``phase_per_raster`` is true,
+    each non-empty grid cell becomes one :class:`Phase`; otherwise the
+    split sub-solids are fused into one new :class:`Phase`.
+
+    :param phase: CAD-backed phase to raster
     :param rve: RVE divided by the given grid
-    :param grid: number of divisions in each direction [x, y, z]
+    :param grid: number of divisions in each direction ``[x, y, z]``
     :param phase_per_raster: if True, returns list of phases
 
     :return: Phase or list of Phases
     """
+    require_cad()
+    from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
+    from OCP.GProp import GProp_GProps  # noqa: PLC0415
+
+    from .cad import make_compound_from_solids  # noqa: PLC0415
     from .phase import Phase  # noqa: PLC0415
 
-    solids = phase.split_solids(rve, grid)
+    if phase.is_empty:
+        err_msg = "Cannot raster an empty phase"
+        raise ValueError(err_msg)
 
-    if phase_per_raster:
-        return Phase.generate_phase_per_raster(solids, rve, grid)
-    return Phase(solids=solids)
+    solids = _split_cad_in_grid(phase.cad, rve, grid)
+
+    if not phase_per_raster:
+        return Phase.from_cad(make_compound_from_solids(solids))
+
+    grid_arr = np.array(grid)
+    buckets: list[list[TopoDS_Shape]] = [[] for _ in range(int(np.prod(grid_arr)))]
+    for solid in solids:
+        props = GProp_GProps()
+        BRepGProp.VolumeProperties_s(solid, props)
+        com = props.CentreOfMass()
+        center = np.array([com.X(), com.Y(), com.Z()])
+        i, j, k = np.floor(
+            grid_arr * (center - rve.min_point) / rve.dim,
+        ).astype(int)
+        ind = i + grid_arr[0] * j + grid_arr[0] * grid_arr[1] * k
+        buckets[int(ind)].append(solid)
+    return [
+        Phase.from_cad(make_compound_from_solids(group)) for group in buckets if group
+    ]
 
 
 def repeat_shape(unit_geom: CadShape, rve: Rve, grid: tuple[int, int, int]) -> CadShape:
@@ -301,11 +379,17 @@ def repeat_shape(unit_geom: CadShape, rve: Rve, grid: tuple[int, int, int]) -> C
     :param rve: RVE of the geometry to repeat
     :param grid: list of number of geometry repetitions in each direction
 
-    :return: cq shape of the repeated geometry
+    :return: CadShape of the repeated geometry
     """
-    from .phase import Phase  # noqa: PLC0415
+    require_cad()
+    from .cad import make_compound_from_solids, translate_solid  # noqa: PLC0415
 
-    return Phase.repeat_shape(unit_geom, rve, grid)
+    center = np.array(unit_geom.center().to_tuple())
+    copies = []
+    for idx in np.ndindex(*grid):
+        pos = center - rve.dim * (0.5 * np.array(grid) - 0.5 - np.array(idx))
+        copies.append(translate_solid(unit_geom.wrapped, pos))
+    return make_compound_from_solids(copies)
 
 
 def repeat_polydata(

--- a/microgen/periodic.py
+++ b/microgen/periodic.py
@@ -289,10 +289,10 @@ def periodic_split_and_translate(phase: Phase, rve: Rve) -> Phase:
 
     :return: resulting Phase
     """
-    shape = phase.shape
-    if shape is None:
+    if phase.is_empty:
         err_msg = "Cannot apply periodic_split_and_translate to an empty phase"
         raise ValueError(err_msg)
+    shape = phase.cad
 
     intersected_faces, rve_planes, partitions = _detect_intersected_faces(shape, rve)
 
@@ -341,8 +341,8 @@ def periodic_split_and_translate(phase: Phase, rve: Rve) -> Phase:
             "periodic_split_and_translate produced no solids",
             stacklevel=2,
         )
-        return Phase(shape=shape)
+        return Phase.from_cad(shape, name=phase.name)
 
     to_fuse = [CadShape(s) for s in all_solids]
     fused = fuse_shapes(to_fuse, retain_edges=False)
-    return Phase(shape=fused)
+    return Phase.from_cad(fused, name=phase.name)

--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -1,351 +1,749 @@
-"""Phase class: a collection of OCCT solids belonging to the same phase.
+"""Phase 2.0 — implicit-first, CAD-optional, ``Piece``-aware container.
 
-The CAD path goes through OCCT directly via ``OCP`` (installed as the
-``[cad]`` extra — ``cadquery-ocp-novtk``); no ``cadquery`` anywhere.  Shapes are
-stored as :class:`microgen.cad.CadShape` and solids as raw OCCT
-``TopoDS_Solid``.
+A :class:`Phase` is a region of space identified by an implicit scalar
+field (the canonical representation), with derived materialisations on
+demand:
+
+- :meth:`grid` / :meth:`surface_mesh` / :meth:`volume_mesh` — PyVista views
+- :attr:`cad` — OCCT BREP via :func:`microgen.cad.shape_to_cad`
+- :attr:`pieces` — connected components of ``{field < iso}`` (the
+  "Phase = collection of cut/split sub-solids" invariant)
+- :attr:`center_of_mass` / :attr:`inertia_matrix` — moments via grid
+  quadrature (field-backed) or BRepGProp (CAD-backed)
+
+Three construction paths:
+
+- :class:`Phase` ``(field=..., bounds=..., iso=..., period=...)`` —
+  field-first (no CAD required).
+- :meth:`Phase.from_shape` — sugar over the field-first path; bridges
+  from a :class:`~microgen.shape.shape.Shape`.
+- :meth:`Phase.from_cad` — CAD-backed; required when loading a STEP file
+  or wrapping a pre-built BREP.
+
+The CAD seam is isolated in :meth:`_materialise_cad`. Switching from
+``microgen.cad`` to ``pyvista-cad`` later means swapping that one method;
+no other code in microgen needs to change.
+
+A :class:`Phase` is **immutable**: transforms (:meth:`translated`,
+:meth:`scaled`, :meth:`rotated`, :meth:`tiled`) return a new instance.
+This makes cache invalidation impossible by construction.
 """
 
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING
+import itertools
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import numpy.typing as npt
-
-from .cad import (
-    CadShape,
-    enumerate_solids,
-    make_compound_from_solids,
-    make_plane_face,
-    split_shape,
-    transform_geometry,
-    translate_solid,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from OCP.TopoDS import TopoDS_Shape, TopoDS_Solid
+    import numpy.typing as npt
+    import pyvista as pv
 
     from .rve import Rve
-
-    ShapeLike = CadShape | TopoDS_Shape
-
-
-def _require_ocp() -> None:
-    """Raise :class:`ImportError` with an install hint if OCP isn't available."""
-    try:
-        import OCP  # noqa: F401, PLC0415
-    except ImportError as err:
-        err_msg = (
-            "This Phase operation requires the CAD extra: pip install 'microgen[cad]'"
-        )
-        raise ImportError(err_msg) from err
+    from .shape._types import BoundsType, Field, PeriodType
+    from .shape.shape import Shape
 
 
-def _to_cad_shape(obj: ShapeLike) -> CadShape:
-    """Coerce a ``CadShape`` or raw ``TopoDS_Shape`` into a :class:`CadShape`."""
-    if isinstance(obj, CadShape):
-        return obj
-    return CadShape(obj.wrapped if hasattr(obj, "wrapped") else obj)
+# Module-level counter for auto-naming (replaces the old mutable
+# ``Phase.num_instances`` class attribute, which contaminated test runs).
+_PHASE_AUTONAME_COUNTER = itertools.count()
+
+
+_IMPLICIT_SCALAR = "implicit"
+
+
+@dataclass(frozen=True)
+class Piece:
+    """One connected sub-region of a :class:`Phase`.
+
+    Pieces are what survives "split this phase under periodicity" or
+    "raster this phase into a per-cell grid" — they expose the per-piece
+    geometric moments without forcing every Phase to be a list of solids.
+
+    Payload fields are populated lazily and may be ``None`` depending on
+    how the parent :class:`Phase` was constructed: a CAD-backed phase
+    populates ``cad``; a field-backed phase populates ``voxel_mask``;
+    a mesh-backed phase populates ``mesh``.
+    """
+
+    com: tuple[float, float, float]
+    volume: float
+    bounds: BoundsType
+    cad: Any | None = None
+    mesh: pv.PolyData | None = None
+    voxel_mask: npt.NDArray[np.bool_] | None = None
 
 
 class Phase:
-    """Phase class: a collection of solids with shared material properties.
+    """Microstructure phase (implicit-first, CAD-optional).
 
-    Exposes:
+    A phase is **one** of the three:
 
-    - :attr:`center_of_mass`
-    - :attr:`inertia_matrix`
-    - :attr:`shape` (a :class:`~microgen.cad.CadShape`)
-    - :attr:`solids` (a list of raw OCCT ``TopoDS_Solid``)
+    - field-backed: a callable ``field(x,y,z) -> array`` with negative
+      values inside, plus an AABB ``bounds`` and an ``iso`` value (the
+      solid is ``{p : field(p) < iso}``).
+    - mesh-backed: a triangulated surface ``pv.PolyData``.
+    - CAD-backed: a CAD shape (``microgen.cad.CadShape`` today, any
+      duck-typed CAD object — including future ``pyvista-cad`` shapes —
+      tomorrow).
 
-    :param shape: a :class:`~microgen.cad.CadShape` or raw ``TopoDS_Shape``
-    :param solids: list of raw OCCT solids
-    :param center: center
-    :param orientation: orientation
+    The other two materialisations are derived on demand.
+
+    :param field: SDF / level-set ``(x, y, z) -> array``; negative inside.
+        Required for field-backed construction.
+    :param bounds: axis-aligned bbox ``(xmin, xmax, ymin, ymax, zmin, zmax)``
+        spanning the field.  Required if ``field`` is set.
+    :param iso: iso-value; the solid is ``{p : field(p) < iso}``.
+        Defaults to ``0.0``.
+    :param period: ``(Lx, Ly, Lz)`` if the field is intrinsically
+        periodic.  Optional.
+    :param name: phase name (defaults to auto-generated ``Phase_N``).
+    :param resolution: default sampling resolution used by lazy
+        :meth:`grid` / :meth:`surface_mesh` / :meth:`pieces`.
+
+    Use :meth:`from_shape`, :meth:`from_cad` or :meth:`from_mesh` to
+    build from a :class:`~microgen.shape.shape.Shape`, a pre-built CAD
+    object, or a triangulated mesh, respectively.
     """
-
-    num_instances = 0
 
     def __init__(
         self: Phase,
-        shape: ShapeLike | None = None,
-        solids: list[TopoDS_Solid] | None = None,
-        center: tuple[float, float, float] | None = None,
-        orientation: tuple[float, float, float] | None = None,
+        *,
+        field: Field | None = None,
+        bounds: BoundsType | None = None,
+        iso: float = 0.0,
+        period: PeriodType | None = None,
+        name: str | None = None,
+        resolution: int = 50,
     ) -> None:
-        """Initialize the phase object."""
-        self._shape: CadShape | None = (
-            _to_cad_shape(shape) if shape is not None else None
-        )
-        self._solids: list[TopoDS_Solid] = solids if solids is not None else []
-        self.center = center
-        self.orientation = orientation
-
-        if shape is None and solids == []:
-            warnings.warn("Empty phase", stacklevel=2)
-
-        self.name = f"Phase_{self.num_instances}"
-
-        self._center_of_mass = None
-        self._inertia_matrix = None
-
-        Phase.num_instances += 1
-
-    def get_center_of_mass(
-        self: Phase,
-        *,
-        compute: bool = True,
-    ) -> npt.NDArray[np.float64]:
-        """Return the center of 'mass' of the phase.
-
-        :param compute: if False and center_of_mass already exists, \
-            does not compute it (use carefully)
-        """
-        if isinstance(self._center_of_mass, np.ndarray) and not compute:
-            return self._center_of_mass
-        self._center_of_mass = self._compute_center_of_mass()
-        return self._center_of_mass
-
-    center_of_mass = property(get_center_of_mass)
-
-    def _compute_center_of_mass(self: Phase) -> npt.NDArray[np.float64]:
-        """Calculate the center of 'mass' of the phase."""
-        _require_ocp()
-        from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
-        from OCP.GProp import GProp_GProps  # noqa: PLC0415
-
-        if self.shape is None:
-            err_msg = "Cannot compute center of mass on an empty phase"
+        """Initialize the phase (keyword-only; positional args rejected)."""
+        if field is not None and bounds is None:
+            err_msg = "bounds must be provided when field is set"
             raise ValueError(err_msg)
 
-        properties = GProp_GProps()
-        BRepGProp.VolumeProperties_s(self.shape.wrapped, properties)
+        self._field: Field | None = field
+        self._bounds: BoundsType | None = bounds
+        self._iso: float = float(iso)
+        self._period: PeriodType | None = period
+        self._resolution: int = int(resolution)
+        # Internal caches for non-field-backed payloads. Materialisation
+        # rules: CAD-backed phases set ``_cad`` at construction; field-backed
+        # phases populate it lazily in :attr:`cad`; mesh-backed phases set
+        # ``_surface_mesh`` at construction.
+        self._cad: Any | None = None
+        self._surface_mesh: pv.PolyData | None = None
 
-        com = properties.CentreOfMass()
-        return np.array([com.X(), com.Y(), com.Z()])
-
-    def get_inertia_matrix(
-        self: Phase,
-        *,
-        compute: bool = True,
-    ) -> npt.NDArray[np.float64]:
-        """Calculate the inertia matrix of the phase.
-
-        :param compute: if False and inertia_matrix already exists, \
-            does not compute it (use carefully)
-        """
-        if isinstance(self._inertia_matrix, np.ndarray) and not compute:
-            return self._inertia_matrix
-        self._inertia_matrix = self._compute_inertia_matrix()
-        return self._inertia_matrix
-
-    inertia_matrix = property(get_inertia_matrix)
-
-    def _compute_inertia_matrix(self: Phase) -> npt.NDArray[np.float64]:
-        """Calculate the inertia matrix of the phase."""
-        _require_ocp()
-        from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
-        from OCP.GProp import GProp_GProps  # noqa: PLC0415
-
-        if self.shape is None:
-            err_msg = "Cannot compute inertia matrix on an empty phase"
-            raise ValueError(err_msg)
-
-        properties = GProp_GProps()
-        BRepGProp.VolumeProperties_s(self.shape.wrapped, properties)
-
-        inm = properties.MatrixOfInertia()
-        return np.array(
-            [
-                [inm.Value(1, 1), inm.Value(1, 2), inm.Value(1, 3)],
-                [inm.Value(2, 1), inm.Value(2, 2), inm.Value(2, 3)],
-                [inm.Value(3, 1), inm.Value(3, 2), inm.Value(3, 3)],
-            ],
+        self.name: str = (
+            name if name is not None else f"Phase_{next(_PHASE_AUTONAME_COUNTER)}"
         )
 
-    @property
-    def shape(self: Phase) -> CadShape | None:
-        """Return the shape of the phase as a :class:`~microgen.cad.CadShape`."""
-        if self._shape is not None:
-            return self._shape
-        if len(self._solids) > 0:
-            self._shape = make_compound_from_solids(self._solids)
-            return self._shape
-
-        warnings.warn("No shape or solids", stacklevel=2)
-        return None
-
-    @property
-    def solids(self: Phase) -> list[TopoDS_Solid]:
-        """Return the list of OCCT ``TopoDS_Solid`` in the phase."""
-        if len(self._solids) > 0:
-            return self._solids
-        if self._shape is not None:
-            self._solids = enumerate_solids(self._shape)
-            return self._solids
-
-        warnings.warn("No solids or shape", stacklevel=2)
-        return []
-
-    def translate(self: Phase, vec: Sequence[float]) -> None:
-        """Translate phase by a given vector (in place)."""
-        if self._shape is None:
-            err_msg = "Cannot translate a phase with no shape"
-            raise ValueError(err_msg)
-        self._shape = self._shape.translate(vec)
-        self._center_of_mass = self._compute_center_of_mass()
-
-    @staticmethod
-    def rescale_shape(
-        shape: ShapeLike,
-        scale: float | tuple[float, float, float],
-    ) -> CadShape:
-        """Rescale ``shape`` by ``scale`` = ``(sx, sy, sz)`` (or a scalar).
-
-        Preserves the shape's center of mass — scaling is performed about it.
-        """
-        shape = _to_cad_shape(shape)
-        if isinstance(scale, float):
-            scale = (scale, scale, scale)
-
-        center = shape.center()
-        cx, cy, cz = center.x, center.y, center.z
-        sx, sy, sz = (float(s) for s in scale)
-
-        # Equivalent to: translate(-c) → scale about origin → translate(+c)
-        # Expressed as a single 3x4 affine matrix for BRepBuilderAPI_GTransform.
-        matrix = np.array(
-            [
-                [sx, 0.0, 0.0, cx - sx * cx],
-                [0.0, sy, 0.0, cy - sy * cy],
-                [0.0, 0.0, sz, cz - sz * cz],
-            ],
-            dtype=np.float64,
-        )
-        return transform_geometry(shape, matrix)
-
-    def rescale(self: Phase, scale: float | tuple[float, float, float]) -> None:
-        """Rescale phase (in place) by ``scale = (sx, sy, sz)`` or a scalar."""
-        if self._shape is None:
-            err_msg = "Cannot rescale a phase with no shape"
-            raise ValueError(err_msg)
-        self._shape = self.rescale_shape(self._shape, scale)
-
-    @staticmethod
-    def repeat_shape(
-        unit_geom: ShapeLike,
-        rve: Rve,
-        grid: tuple[int, int, int],
-    ) -> CadShape:
-        """Repeat ``unit_geom`` on a ``grid`` within the ``rve`` periodicity cell.
-
-        Returns a :class:`~microgen.cad.CadShape` wrapping an OCCT compound
-        of translated copies of ``unit_geom``.
-        """
-        unit_geom = _to_cad_shape(unit_geom)
-        center = np.array(unit_geom.center().to_tuple())
-
-        copies: list[TopoDS_Solid] = []
-        for idx in np.ndindex(*grid):
-            pos = center - rve.dim * (0.5 * np.array(grid) - 0.5 - np.array(idx))
-            copies.append(translate_solid(unit_geom.wrapped, pos))
-        return make_compound_from_solids(copies)
-
-    def repeat(self: Phase, rve: Rve, grid: tuple[int, int, int]) -> None:
-        """Repeat phase in place on a ``grid`` within the ``rve`` periodicity cell."""
-        if self.shape is None:
-            err_msg = "Cannot repeat a phase with no shape"
-            raise ValueError(err_msg)
-        self._shape = self.repeat_shape(self.shape, rve, grid)
-
-    def split_solids(self: Phase, rve: Rve, grid: list[int]) -> list[TopoDS_Solid]:
-        """Split solids from phase according to the rve divided by the given grid.
-
-        Each solid is split by the (grid-1) interior planes along each axis;
-        planes are constructed with :func:`microgen.cad.make_plane_face` and
-        applied through OCCT's ``BRepAlgoAPI_Splitter``.
-
-        :param rve: RVE divided by the given grid
-        :param grid: number of divisions in each direction ``[x, y, z]``
-
-        :return: list of raw OCCT ``TopoDS_Solid``
-        """
-        result: list[TopoDS_Solid] = []
-        for solid in self.solids:
-            current = CadShape(solid)
-            for dim in range(3):
-                direction = tuple(int(dim == i) for i in range(3))
-                coords = np.linspace(
-                    start=rve.min_point[dim],
-                    stop=rve.max_point[dim],
-                    num=grid[dim],
-                    endpoint=False,
-                )[1:]
-                for pos in coords:
-                    base_pnt = tuple(float(pos) * direction[k] for k in range(3))
-                    plane = make_plane_face(base_pnt, direction)
-                    current = split_shape(current, plane)
-            result.extend(enumerate_solids(current))
-        return result
-
-    def rasterize(
-        self: Phase,
-        rve: Rve,
-        grid: list[int],
-        *,
-        phase_per_raster: bool = True,
-    ) -> list[Phase] | None:
-        """Raster solids from phase according to the rve divided by the given grid.
-
-        :param rve: RVE divided by the given grid
-        :param grid: number of divisions in each direction [x, y, z]
-        :param phase_per_raster: if True, returns list of phases
-
-        :return: list of Phases if required
-        """
-        solids = self.split_solids(rve, grid)
-
-        if phase_per_raster:
-            return self.generate_phase_per_raster(solids, rve, grid)
-        self._solids = solids
-        self._shape = make_compound_from_solids(self._solids)
-        return None
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
 
     @classmethod
-    def generate_phase_per_raster(
+    def from_shape(
         cls: type[Phase],
-        solids: list[TopoDS_Solid],
-        rve: Rve,
-        grid: list[int],
-    ) -> list[Phase]:
-        """Raster solids into per-grid-cell Phases.
+        shape: Shape,
+        *,
+        bounds: BoundsType | None = None,
+        iso: float = 0.0,
+        name: str | None = None,
+        resolution: int = 50,
+    ) -> Phase:
+        """Construct a field-backed :class:`Phase` from an implicit :class:`Shape`.
 
-        :param solids: list of OCCT solids
-        :param rve: RVE divided by the given grid
-        :param grid: number of divisions in each direction ``[x, y, z]``
+        Inherits ``field``, ``bounds``, and ``period`` from the shape.
+        ``bounds`` may be overridden (e.g., to clip a periodic field to a
+        sub-region).
 
-        :return: list of :class:`Phase`
+        :param shape: source implicit shape; must have ``func is not None``.
+        :param bounds: override the shape's bounds; defaults to ``shape.bounds``.
+        :param iso: iso-value (default ``0.0``).
+        :param name: phase name (auto-generated if omitted).
+        :param resolution: default sampling resolution.
         """
-        _require_ocp()
-        from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
-        from OCP.GProp import GProp_GProps  # noqa: PLC0415
+        if shape.func is None:
+            err_msg = "Cannot build Phase from a Shape without an implicit field"
+            raise ValueError(err_msg)
+        actual_bounds = bounds if bounds is not None else shape.bounds
+        if actual_bounds is None:
+            err_msg = (
+                "Source Shape has no bounds — pass `bounds=` "
+                "explicitly to Phase.from_shape()"
+            )
+            raise ValueError(err_msg)
+        return cls(
+            field=shape.func,
+            bounds=actual_bounds,
+            iso=iso,
+            period=shape.period,
+            name=name,
+            resolution=resolution,
+        )
 
-        grid_arr = np.array(grid)
-        solids_phases: list[list[TopoDS_Solid]] = [
-            [] for _ in range(int(np.prod(grid_arr)))
-        ]
-        for solid in solids:
+    @classmethod
+    def from_cad(
+        cls: type[Phase],
+        cad: Any,
+        *,
+        name: str | None = None,
+    ) -> Phase:
+        """Construct a CAD-backed :class:`Phase`.
+
+        ``cad`` may be a :class:`microgen.cad.CadShape` or any duck-typed
+        object with ``.solids()``, ``.center()``, ``.volume()``,
+        ``.bounding_box()`` methods (this is the seam that lets a future
+        ``pyvista-cad`` backend drop in without touching :class:`Phase`).
+
+        :param cad: a CAD shape (``CadShape`` today)
+        :param name: phase name (auto-generated if omitted)
+        """
+        from .cad import CadShape  # noqa: PLC0415
+
+        if not isinstance(cad, CadShape) and hasattr(cad, "wrapped"):
+            cad = CadShape(cad.wrapped)
+
+        instance = cls(name=name)
+        instance._cad = cad  # noqa: SLF001
+        return instance
+
+    @classmethod
+    def from_mesh(
+        cls: type[Phase],
+        mesh: pv.PolyData,
+        *,
+        name: str | None = None,
+    ) -> Phase:
+        """Construct a mesh-backed :class:`Phase` from a closed surface mesh.
+
+        :param mesh: closed triangulated surface
+        :param name: phase name (auto-generated if omitted)
+        """
+        instance = cls(name=name)
+        instance._surface_mesh = mesh  # noqa: SLF001
+        return instance
+
+    # ------------------------------------------------------------------
+    # Read-only accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def field(self: Phase) -> Field | None:
+        """The implicit scalar field, or ``None`` for non-field-backed phases."""
+        return self._field
+
+    @property
+    def bounds(self: Phase) -> BoundsType | None:
+        """AABB ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+
+        For field-backed phases this is set at construction.  For CAD- or
+        mesh-backed phases it's derived from the underlying representation.
+        """
+        if self._bounds is not None:
+            return self._bounds
+        if self._cad is not None:
+            bb = self._cad.bounding_box()
+            return (bb.xmin, bb.xmax, bb.ymin, bb.ymax, bb.zmin, bb.zmax)
+        if self._surface_mesh is not None:
+            xmin, xmax, ymin, ymax, zmin, zmax = self._surface_mesh.bounds
+            return (
+                float(xmin),
+                float(xmax),
+                float(ymin),
+                float(ymax),
+                float(zmin),
+                float(zmax),
+            )
+        return None
+
+    @property
+    def iso(self: Phase) -> float:
+        """Iso-value for the implicit field (the solid is ``{field < iso}``)."""
+        return self._iso
+
+    @property
+    def period(self: Phase) -> PeriodType | None:
+        """Intrinsic period ``(Lx, Ly, Lz)`` if the field is periodic."""
+        return self._period
+
+    @property
+    def resolution(self: Phase) -> int:
+        """Default sampling resolution for lazy grid/mesh/pieces materialisation."""
+        return self._resolution
+
+    @property
+    def is_empty(self: Phase) -> bool:
+        """True if the phase has no backing representation."""
+        return self._field is None and self._cad is None and self._surface_mesh is None
+
+    # ------------------------------------------------------------------
+    # CAD materialisation (the pyvista-cad seam lives here)
+    # ------------------------------------------------------------------
+
+    def _materialise_cad(self: Phase) -> Any:
+        """Build a CAD representation from the field (or surface mesh).
+
+        This is the **single seam** where :class:`Phase` talks to a CAD
+        backend.  Swapping ``microgen.cad`` for ``pyvista-cad`` later
+        means rewriting this method only.
+
+        Requires the optional ``[cad]`` extra today.
+        """
+        if self._field is not None and self._bounds is not None:
+            # Wrap field+bounds in a transient Shape and call shape_to_cad.
+            from .cad import shape_to_cad  # noqa: PLC0415
+            from .shape.shape import Shape  # noqa: PLC0415
+
+            transient = Shape(func=self._field, bounds=self._bounds)
+            return shape_to_cad(
+                transient, bounds=self._bounds, resolution=self._resolution
+            )
+        if self._surface_mesh is not None:
+            from .cad import mesh_to_shape  # noqa: PLC0415
+
+            mesh = self._surface_mesh
+            if not mesh.is_all_triangles:
+                mesh = mesh.triangulate()
+            triangles = mesh.faces.reshape(-1, 4)[:, 1:]
+            points = np.asarray(mesh.points, dtype=np.float64)
+            return mesh_to_shape(points, triangles)
+        err_msg = "Cannot materialise CAD: phase has no field or mesh"
+        raise ValueError(err_msg)
+
+    @cached_property
+    def cad(self: Phase) -> Any:
+        """The CAD representation (``microgen.cad.CadShape`` today, lazy).
+
+        For CAD-backed phases this returns the stored shape.  For
+        field-backed or mesh-backed phases it's lazily materialised via
+        :meth:`_materialise_cad`.
+
+        Requires the ``[cad]`` extra (raises ``ImportError`` otherwise).
+        """
+        if self._cad is not None:
+            return self._cad
+        return self._materialise_cad()
+
+    # ------------------------------------------------------------------
+    # PyVista views (lazy, per-resolution caches via @cached_property are
+    # not used here because the resolution kwarg differs per call)
+    # ------------------------------------------------------------------
+
+    def grid(self: Phase, resolution: int | None = None) -> pv.StructuredGrid:
+        """Return a structured grid sampling of the field.
+
+        Only meaningful for field-backed phases.
+        """
+        if self._field is None or self._bounds is None:
+            err_msg = "grid() requires a field-backed Phase"
+            raise ValueError(err_msg)
+        import pyvista as pv  # noqa: PLC0415
+
+        res = int(resolution) if resolution is not None else self._resolution
+        xmin, xmax, ymin, ymax, zmin, zmax = self._bounds
+        xi = np.linspace(xmin, xmax, res)
+        yi = np.linspace(ymin, ymax, res)
+        zi = np.linspace(zmin, zmax, res)
+        x, y, z = np.meshgrid(xi, yi, zi, indexing="ij")
+        sg = pv.StructuredGrid(x, y, z)
+        sg[_IMPLICIT_SCALAR] = self._field(
+            x.ravel(order="F"), y.ravel(order="F"), z.ravel(order="F")
+        )
+        return sg
+
+    def surface_mesh(self: Phase, resolution: int | None = None) -> pv.PolyData:
+        """Return a triangulated surface mesh of the solid boundary.
+
+        - Mesh-backed phase: returns the stored mesh.
+        - Field-backed phase: marching cubes on the sampled grid.
+        - CAD-backed phase: tessellates via OCCT incremental mesh.
+        """
+        import pyvista as pv  # noqa: PLC0415
+
+        if self._surface_mesh is not None:
+            return self._surface_mesh
+        if self._field is not None:
+            sg = self.grid(resolution)
+            iso = pv.PolyData(
+                sg.contour(isosurfaces=[self._iso], scalars=_IMPLICIT_SCALAR)
+            )
+            return iso.clean().triangulate() if iso.n_cells > 0 else pv.PolyData()
+        if self._cad is not None:
+            err_msg = (
+                "surface_mesh() on a CAD-backed Phase is not implemented yet "
+                "(would need OCCT BRepMesh_IncrementalMesh tessellation)."
+            )
+            raise NotImplementedError(err_msg)
+        err_msg = "Cannot build surface_mesh on an empty Phase"
+        raise ValueError(err_msg)
+
+    def volume_mesh(self: Phase, resolution: int | None = None) -> pv.UnstructuredGrid:
+        """Return the volumetric cells where ``field < iso``.
+
+        Only meaningful for field-backed phases.
+        """
+        if self._field is None:
+            err_msg = "volume_mesh() requires a field-backed Phase"
+            raise ValueError(err_msg)
+        sg = self.grid(resolution)
+        return sg.clip_scalar(scalars=_IMPLICIT_SCALAR, value=self._iso, invert=True)
+
+    # ------------------------------------------------------------------
+    # Pieces — the "Phase = collection of cut/split sub-solids" invariant
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def pieces(self: Phase) -> list[Piece]:
+        """Connected components of the phase (the "sub-pieces" invariant).
+
+        - CAD-backed phase: one :class:`Piece` per ``TopoDS_Solid``.
+        - Field-backed phase: ``scipy.ndimage.label`` on
+          ``grid_field < iso``; one piece per connected component.
+        - Mesh-backed phase: ``polydata.connectivity().split_bodies()``.
+        """
+        if self._cad is not None:
+            return self._pieces_from_cad()
+        if self._field is not None:
+            return self._pieces_from_field()
+        if self._surface_mesh is not None:
+            return self._pieces_from_mesh()
+        return []
+
+    def _pieces_from_cad(self: Phase) -> list[Piece]:
+        from .cad import CadShape  # noqa: PLC0415
+
+        out: list[Piece] = []
+        for solid in self._cad.solids():
+            wrapped = solid if isinstance(solid, CadShape) else CadShape(solid)
+            c = wrapped.center()
+            bb = wrapped.bounding_box()
+            out.append(
+                Piece(
+                    com=(float(c.x), float(c.y), float(c.z)),
+                    volume=float(wrapped.volume()),
+                    bounds=(bb.xmin, bb.xmax, bb.ymin, bb.ymax, bb.zmin, bb.zmax),
+                    cad=wrapped,
+                )
+            )
+        return out
+
+    def _pieces_from_field(self: Phase) -> list[Piece]:
+        from scipy.ndimage import center_of_mass, find_objects, label  # noqa: PLC0415
+
+        sg = self.grid()
+        res = self._resolution
+        scalar = np.asarray(sg[_IMPLICIT_SCALAR]).reshape((res, res, res), order="F")
+        inside = scalar < self._iso
+        labels, n_labels = label(inside)
+        if n_labels == 0:
+            return []
+
+        xmin, xmax, ymin, ymax, zmin, zmax = self._bounds  # type: ignore[misc]
+        dx = (xmax - xmin) / (res - 1)
+        dy = (ymax - ymin) / (res - 1)
+        dz = (zmax - zmin) / (res - 1)
+        cell_volume = dx * dy * dz
+
+        coms = center_of_mass(inside, labels=labels, index=range(1, n_labels + 1))
+        slices = find_objects(labels)
+
+        out: list[Piece] = []
+        for label_id in range(1, n_labels + 1):
+            mask = labels == label_id
+            voxel_count = int(mask.sum())
+            com_voxel = coms[label_id - 1]
+            com_world = (
+                xmin + com_voxel[0] * dx,
+                ymin + com_voxel[1] * dy,
+                zmin + com_voxel[2] * dz,
+            )
+            sl = slices[label_id - 1]
+            piece_bounds = (
+                xmin + sl[0].start * dx,
+                xmin + (sl[0].stop - 1) * dx,
+                ymin + sl[1].start * dy,
+                ymin + (sl[1].stop - 1) * dy,
+                zmin + sl[2].start * dz,
+                zmin + (sl[2].stop - 1) * dz,
+            )
+            out.append(
+                Piece(
+                    com=com_world,
+                    volume=voxel_count * cell_volume,
+                    bounds=piece_bounds,
+                    voxel_mask=mask,
+                )
+            )
+        return out
+
+    def _pieces_from_mesh(self: Phase) -> list[Piece]:
+        out: list[Piece] = []
+        for body in self._surface_mesh.split_bodies():  # type: ignore[union-attr]
+            poly = body.extract_surface()
+            com = poly.center_of_mass()
+            xmin, xmax, ymin, ymax, zmin, zmax = poly.bounds
+            out.append(
+                Piece(
+                    com=(float(com[0]), float(com[1]), float(com[2])),
+                    volume=float(poly.volume),
+                    bounds=(
+                        float(xmin),
+                        float(xmax),
+                        float(ymin),
+                        float(ymax),
+                        float(zmin),
+                        float(zmax),
+                    ),
+                    mesh=poly,
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Moments
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def center_of_mass(self: Phase) -> npt.NDArray[np.float64]:
+        """Volumetric center of mass.
+
+        For field-backed phases this is computed by quadrature on the
+        sampled grid (no OCCT needed).  For CAD-backed phases this uses
+        ``BRepGProp.VolumeProperties_s``.
+        """
+        if self._cad is not None:
+            from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
+            from OCP.GProp import GProp_GProps  # noqa: PLC0415
+
             props = GProp_GProps()
-            BRepGProp.VolumeProperties_s(solid, props)
+            BRepGProp.VolumeProperties_s(self._cad.wrapped, props)
             com = props.CentreOfMass()
-            center = np.array([com.X(), com.Y(), com.Z()])
-            i, j, k = np.floor(
-                grid_arr * (center - rve.min_point) / rve.dim,
-            ).astype(int)
-            ind = i + grid_arr[0] * j + grid_arr[0] * grid_arr[1] * k
-            solids_phases[int(ind)].append(solid)
-        return [Phase(solids=solids) for solids in solids_phases if len(solids) > 0]
+            return np.array([com.X(), com.Y(), com.Z()])
+        if self._field is not None:
+            sg = self.grid()
+            res = self._resolution
+            scalar = np.asarray(sg[_IMPLICIT_SCALAR]).reshape(
+                (res, res, res), order="F"
+            )
+            inside = scalar < self._iso
+            if not inside.any():
+                err_msg = "center_of_mass: field is positive everywhere on the grid"
+                raise ValueError(err_msg)
+            pts = np.asarray(sg.points).reshape((res, res, res, 3), order="F")
+            mask = inside.astype(np.float64)
+            denom = float(mask.sum())
+            com = (
+                float((mask * pts[..., 0]).sum() / denom),
+                float((mask * pts[..., 1]).sum() / denom),
+                float((mask * pts[..., 2]).sum() / denom),
+            )
+            return np.array(com)
+        err_msg = "Cannot compute center_of_mass on an empty Phase"
+        raise ValueError(err_msg)
+
+    @cached_property
+    def inertia_matrix(self: Phase) -> npt.NDArray[np.float64]:
+        """Inertia tensor (about the origin) of the phase.
+
+        Field-backed: grid quadrature.  CAD-backed: ``BRepGProp``.
+        """
+        if self._cad is not None:
+            from OCP.BRepGProp import BRepGProp  # noqa: PLC0415
+            from OCP.GProp import GProp_GProps  # noqa: PLC0415
+
+            props = GProp_GProps()
+            BRepGProp.VolumeProperties_s(self._cad.wrapped, props)
+            inm = props.MatrixOfInertia()
+            return np.array(
+                [
+                    [inm.Value(1, 1), inm.Value(1, 2), inm.Value(1, 3)],
+                    [inm.Value(2, 1), inm.Value(2, 2), inm.Value(2, 3)],
+                    [inm.Value(3, 1), inm.Value(3, 2), inm.Value(3, 3)],
+                ]
+            )
+        if self._field is not None:
+            sg = self.grid()
+            res = self._resolution
+            scalar = np.asarray(sg[_IMPLICIT_SCALAR]).reshape(
+                (res, res, res), order="F"
+            )
+            inside = scalar < self._iso
+            if not inside.any():
+                err_msg = "inertia_matrix: field is positive everywhere on the grid"
+                raise ValueError(err_msg)
+            pts = np.asarray(sg.points).reshape((res, res, res, 3), order="F")
+            x = pts[..., 0][inside]
+            y = pts[..., 1][inside]
+            z = pts[..., 2][inside]
+            xmin, xmax, ymin, ymax, zmin, zmax = self._bounds  # type: ignore[misc]
+            dx = (xmax - xmin) / (res - 1)
+            dy = (ymax - ymin) / (res - 1)
+            dz = (zmax - zmin) / (res - 1)
+            cell_volume = dx * dy * dz
+            ixx = float(((y * y + z * z) * cell_volume).sum())
+            iyy = float(((x * x + z * z) * cell_volume).sum())
+            izz = float(((x * x + y * y) * cell_volume).sum())
+            ixy = -float((x * y * cell_volume).sum())
+            ixz = -float((x * z * cell_volume).sum())
+            iyz = -float((y * z * cell_volume).sum())
+            return np.array(
+                [[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]],
+                dtype=np.float64,
+            )
+        err_msg = "Cannot compute inertia_matrix on an empty Phase"
+        raise ValueError(err_msg)
+
+    # ------------------------------------------------------------------
+    # Immutable transforms
+    # ------------------------------------------------------------------
+
+    def translated(self: Phase, offset: Sequence[float]) -> Phase:
+        """Return a new :class:`Phase` translated by ``offset``."""
+        dx, dy, dz = float(offset[0]), float(offset[1]), float(offset[2])
+
+        if self._field is not None and self._bounds is not None:
+            f = self._field
+            new_bounds = (
+                self._bounds[0] + dx,
+                self._bounds[1] + dx,
+                self._bounds[2] + dy,
+                self._bounds[3] + dy,
+                self._bounds[4] + dz,
+                self._bounds[5] + dz,
+            )
+            return Phase(
+                field=lambda x, y, z, _f=f, _dx=dx, _dy=dy, _dz=dz: _f(
+                    x - _dx, y - _dy, z - _dz
+                ),
+                bounds=new_bounds,
+                iso=self._iso,
+                period=self._period,
+                name=self.name,
+                resolution=self._resolution,
+            )
+        if self._cad is not None:
+            new = Phase(name=self.name, resolution=self._resolution)
+            new._cad = self._cad.translate((dx, dy, dz))  # noqa: SLF001
+            return new
+        err_msg = "Cannot translate an empty Phase"
+        raise ValueError(err_msg)
+
+    def scaled(self: Phase, factor: float | tuple[float, float, float]) -> Phase:
+        """Return a new :class:`Phase` scaled by ``factor`` about its center of mass.
+
+        CAD-backed phases use OCCT ``BRepBuilderAPI_GTransform`` about
+        the BRep center.  Field-backed phases compose the field via
+        ``f'(p) = f((p - c) / s + c) * s_min`` (uniform scale only; a
+        per-axis scale is not exact for an SDF, so non-uniform factors
+        rescale the bbox only and leave the field's iso-distance
+        approximate — caller's responsibility).
+        """
+        if self._cad is not None:
+            from .cad import transform_geometry  # noqa: PLC0415
+
+            if isinstance(factor, (int, float)):
+                sx = sy = sz = float(factor)
+            else:
+                sx, sy, sz = (float(s) for s in factor)
+            c = self._cad.center()
+            cx, cy, cz = c.x, c.y, c.z
+            matrix = np.array(
+                [
+                    [sx, 0.0, 0.0, cx - sx * cx],
+                    [0.0, sy, 0.0, cy - sy * cy],
+                    [0.0, 0.0, sz, cz - sz * cz],
+                ],
+                dtype=np.float64,
+            )
+            new = Phase(name=self.name, resolution=self._resolution)
+            new._cad = transform_geometry(self._cad, matrix)  # noqa: SLF001
+            return new
+        if self._field is not None and self._bounds is not None:
+            if isinstance(factor, (int, float)):
+                sx = sy = sz = float(factor)
+            else:
+                sx, sy, sz = (float(s) for s in factor)
+            cx, cy, cz = self.center_of_mass.tolist()
+            f = self._field
+            new_bounds = (
+                cx + (self._bounds[0] - cx) * sx,
+                cx + (self._bounds[1] - cx) * sx,
+                cy + (self._bounds[2] - cy) * sy,
+                cy + (self._bounds[3] - cy) * sy,
+                cz + (self._bounds[4] - cz) * sz,
+                cz + (self._bounds[5] - cz) * sz,
+            )
+            s_min = min(sx, sy, sz)
+            return Phase(
+                field=lambda x, y, z, _f=f, _sx=sx, _sy=sy, _sz=sz, _cx=cx, _cy=cy, _cz=cz, _sm=s_min: (
+                    _f(
+                        (x - _cx) / _sx + _cx,
+                        (y - _cy) / _sy + _cy,
+                        (z - _cz) / _sz + _cz,
+                    )
+                    * _sm
+                ),
+                bounds=new_bounds,
+                iso=self._iso,
+                period=self._period,
+                name=self.name,
+                resolution=self._resolution,
+            )
+        err_msg = "Cannot scale an empty Phase"
+        raise ValueError(err_msg)
+
+    def tiled(self: Phase, rve: Rve, grid: tuple[int, int, int]) -> Phase:
+        """Return a new :class:`Phase` periodically tiled on the RVE.
+
+        Builds ``∏ grid`` translated copies of the current phase and
+        fuses them.  Only implemented for CAD-backed phases today (the
+        field-backed equivalent — domain folding via ``mod`` — lands in
+        a follow-up; the periodic-shape work in
+        :mod:`microgen.shape.implicit_ops` already covers it for
+        :class:`Shape` directly).
+        """
+        if self._cad is None:
+            err_msg = (
+                "Phase.tiled is implemented for CAD-backed phases today; "
+                "field-backed tiling lives on the source Shape (use "
+                "microgen.shape.implicit_ops.repeat there)."
+            )
+            raise NotImplementedError(err_msg)
+        from .cad import (  # noqa: PLC0415
+            make_compound_from_solids,
+            translate_solid,
+        )
+
+        center = np.array(self._cad.center().to_tuple())
+        copies = []
+        for idx in np.ndindex(*grid):
+            pos = center - rve.dim * (0.5 * np.array(grid) - 0.5 - np.array(idx))
+            copies.append(translate_solid(self._cad.wrapped, pos))
+        new = Phase(name=self.name, resolution=self._resolution)
+        new._cad = make_compound_from_solids(copies)  # noqa: SLF001
+        return new
+
+    # ------------------------------------------------------------------
+    # Misc
+    # ------------------------------------------------------------------
+
+    def __repr__(self: Phase) -> str:
+        kind = (
+            "field"
+            if self._field is not None
+            else "cad"
+            if self._cad is not None
+            else "mesh"
+            if self._surface_mesh is not None
+            else "empty"
+        )
+        return f"Phase(name={self.name!r}, kind={kind!r}, bounds={self.bounds})"
+
+
+__all__ = ["Phase", "Piece"]

--- a/microgen/shape/strut_lattice/abstract_lattice.py
+++ b/microgen/shape/strut_lattice/abstract_lattice.py
@@ -243,7 +243,7 @@ class AbstractLattice(Shape):
                 radius=self.strut_radius,
             )
             shape = strut.generate_cad()
-            list_phases.append(Phase(shape))
+            list_phases.append(Phase.from_cad(shape))
         if self.strut_joints:
             for vertex in self.vertices:
                 joint = Sphere(
@@ -251,14 +251,14 @@ class AbstractLattice(Shape):
                     radius=self.strut_radius,
                 )
                 shape = joint.generate_cad()
-                list_phases.append(Phase(shape))
+                list_phases.append(Phase.from_cad(shape))
 
         for phase in list_phases:
             periodic_phase = periodic_split_and_translate(phase=phase, rve=self.rve)
             list_periodic_phases.append(periodic_phase)
 
         lattice = fuse_shapes(
-            [phase.shape for phase in list_periodic_phases],
+            [phase.cad for phase in list_periodic_phases],
             retain_edges=False,
         )
 
@@ -325,7 +325,7 @@ class AbstractLattice(Shape):
                 return cached_mesh
 
         cad_lattice = self.cad_shape
-        list_phases = [Phase(cad_lattice)]
+        list_phases = [Phase.from_cad(cad_lattice)]
 
         with (
             NamedTemporaryFile(suffix=".step", delete=False) as cad_step_file,

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -22,12 +22,12 @@ def test_mesh_rastered_sphere_must_have_correct_number_of_cells() -> None:
 
     grid = [3 for _ in range(3)]
     phases = raster_phase(
-        phase=Phase(shape=Sphere(radius=0.5).generate_cad()),
+        phase=Phase.from_cad(Sphere(radius=0.5).generate_cad()),
         rve=Rve(),
         grid=grid,
     )
     compound = make_compound_from_solids(
-        [solid for phase in phases for solid in phase.solids],
+        [solid.wrapped for phase in phases for solid in phase.cad.solids()],
     )
     compound.export_step("tests/data/compound.step")
 

--- a/tests/test_mesh_periodic.py
+++ b/tests/test_mesh_periodic.py
@@ -94,7 +94,7 @@ def _generate_cqcompound_octettruss(rve: Rve) -> list[Phase]:
             height=height[i],
             radius=radius[i],
         )
-        phase = Phase(shape=elem.generate_cad())
+        phase = Phase.from_cad(elem.generate_cad())
         phases.append(phase)
 
     return [
@@ -110,7 +110,7 @@ def box_homogeneous_unit(rve_unit: Rve) -> tuple[CadShape, list[Phase], Rve]:
         orientation=(0.0, 0.0, 0.0),
         dim=(rve_unit.dim[0], rve_unit.dim[1], rve_unit.dim[2]),
     ).generate_cad()
-    listcqphases = [Phase(shape=shape)]
+    listcqphases = [Phase.from_cad(shape)]
     return (shape, listcqphases, rve_unit)
 
 
@@ -124,7 +124,7 @@ def box_homogeneous_double(
         orientation=(0.0, 0.0, 0.0),
         dim=tuple(rve_double.dim),
     ).generate_cad()
-    listcqphases = [Phase(shape=shape)]
+    listcqphases = [Phase.from_cad(shape)]
     return (shape, listcqphases, rve_double)
 
 
@@ -138,7 +138,7 @@ def box_homogeneous_double_centered(
         orientation=(0.0, 0.0, 0.0),
         dim=tuple(rve_double_centered.dim),
     ).generate_cad()
-    listcqphases = [Phase(shape=shape)]
+    listcqphases = [Phase.from_cad(shape)]
     return (shape, listcqphases, rve_double_centered)
 
 
@@ -149,10 +149,10 @@ def octet_truss_homogeneous_unit(
     """Return a homogeneous unit octet truss."""
     list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
     merged = fuse_shapes(
-        [phase.shape for phase in list_periodic_phases],
+        [phase.cad for phase in list_periodic_phases],
         retain_edges=False,
     )
-    listcqphases = [Phase(shape=merged)]
+    listcqphases = [Phase.from_cad(merged)]
     return (merged, listcqphases, rve_unit)
 
 
@@ -163,10 +163,10 @@ def octet_truss_homogeneous_double_centered(
     """Return a homogeneous double centered octet truss."""
     list_periodic_phases = _generate_cqcompound_octettruss(rve_double_centered)
     merged = fuse_shapes(
-        [phase.shape for phase in list_periodic_phases],
+        [phase.cad for phase in list_periodic_phases],
         retain_edges=False,
     )
-    listcqphases = [Phase(shape=merged)]
+    listcqphases = [Phase.from_cad(merged)]
     return (merged, listcqphases, rve_double_centered)
 
 
@@ -178,7 +178,7 @@ def octet_truss_heterogeneous(
     list_periodic_phases = _generate_cqcompound_octettruss(rve_unit)
     listcqphases = cut_phases(phases=list_periodic_phases, reverse_order=False)
     return (
-        make_compound_from_solids([phase.shape.wrapped for phase in listcqphases]),
+        make_compound_from_solids([phase.cad.wrapped for phase in listcqphases]),
         listcqphases,
         rve_unit,
     )

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -3,7 +3,6 @@
 import pytest
 
 from microgen import Phase, Rve, periodic_split_and_translate, shape
-from microgen.cad import CadShape
 
 # ruff: noqa: S101 assert https://docs.astral.sh/ruff/rules/assert/
 # ruff: noqa: E501 line-too-long https://docs.astral.sh/ruff/rules/line-too-long/
@@ -17,7 +16,7 @@ N_PARTS_ON_CORNER = 8
 def _generate_sphere(x: float, y: float, z: float, rve: Rve) -> Phase:
     """Generate a sphere at the given position and test periodicity."""
     elem = shape.sphere.Sphere(center=(x, y, z), radius=0.1)
-    phase = Phase(shape=elem.generate_cad())
+    phase = Phase.from_cad(elem.generate_cad())
     return periodic_split_and_translate(phase=phase, rve=rve)
 
 
@@ -26,7 +25,7 @@ def test_periodic_generates_warning_on_intersection_with_opposite_faces() -> Non
     rve = Rve(dim=1, center=(0.5, 0.5, 0.5))
 
     elem = shape.capsule.Capsule(center=(0.5, 0, 0.5), height=1, radius=0.1)
-    phase = Phase(shape=elem.generate_cad())
+    phase = Phase.from_cad(elem.generate_cad())
 
     expected_warning_msg = r"Object intersecting ([xyz])\+ and ([xyz])\- faces: not doing anything in this direction"
     with pytest.warns(UserWarning, match=expected_warning_msg):
@@ -37,7 +36,7 @@ def test_periodic_when_no_intersection() -> None:
     """Test that the periodic function does not raise an error when there is no intersection."""
     rve = Rve(dim=1, center=(0.5, 0.5, 0.5))
     phase = _generate_sphere(x=0.5, y=0.5, z=0.5, rve=rve)
-    assert len(phase.solids) == N_PARTS_NO_INTERSECTION
+    assert len(phase.pieces) == N_PARTS_NO_INTERSECTION
 
 
 @pytest.mark.parametrize(
@@ -55,7 +54,7 @@ def test_periodic_when_intersection_with_one_face(x: float, y: float, z: float) 
     """Test that the periodic function does not raise an error when there is an intersection with one face."""
     rve = Rve(dim=1, center=(0.5, 0.5, 0.5))
     phase = _generate_sphere(x=x, y=y, z=z, rve=rve)
-    assert len(phase.solids) == N_PARTS_ON_FACE
+    assert len(phase.pieces) == N_PARTS_ON_FACE
 
 
 @pytest.mark.parametrize(
@@ -79,7 +78,7 @@ def test_periodic_when_intersection_with_one_edge(x: float, y: float, z: float) 
     """Test that the periodic function does not raise an error when there is an intersection with one face."""
     rve = Rve(dim=1, center=(0.5, 0.5, 0.5))
     phase = _generate_sphere(x=x, y=y, z=z, rve=rve)
-    assert len(phase.solids) == N_PARTS_ON_EDGE
+    assert len(phase.pieces) == N_PARTS_ON_EDGE
 
 
 @pytest.mark.parametrize(
@@ -104,7 +103,7 @@ def test_periodic_when_intersection_with_one_corner(
     rve = Rve(dim=1, center=(0.5, 0.5, 0.5))
 
     phase = _generate_sphere(x=x, y=y, z=z, rve=rve)
-    assert len(phase.solids) == N_PARTS_ON_CORNER
+    assert len(phase.pieces) == N_PARTS_ON_CORNER
 
 
 # Volume- and bounds-based regression checks for the OCP-direct rewrite of
@@ -122,9 +121,8 @@ _VOL_REL_TOL = 5e-3  # OCCT booleans have small volumetric drift
 
 
 def _total_volume(phase: Phase) -> float:
-    # phase.solids is a list of raw TopoDS_Solid; wrap each so we can call
-    # the CadShape helpers (Volume / BoundingBox).
-    return sum(float(CadShape(s).volume()) for s in phase.solids)
+    # ``phase.pieces`` carries the per-sub-solid volume directly.
+    return sum(piece.volume for piece in phase.pieces)
 
 
 def _all_solids_inside(phase: Phase, rve: Rve, tol: float = 1e-3) -> bool:
@@ -133,15 +131,15 @@ def _all_solids_inside(phase: Phase, rve: Rve, tol: float = 1e-3) -> bool:
     # box.  A misplaced fragment from a sign error would be off by O(rve.dim),
     # so 1e-3 is loose enough for OCCT noise yet tight enough to catch the
     # bug class this test targets.
-    for solid in phase.solids:
-        bb = CadShape(solid).bounding_box()
+    for piece in phase.pieces:
+        xmin, xmax, ymin, ymax, zmin, zmax = piece.bounds
         if (
-            bb.xmin < rve.min_point[0] - tol
-            or bb.xmax > rve.max_point[0] + tol
-            or bb.ymin < rve.min_point[1] - tol
-            or bb.ymax > rve.max_point[1] + tol
-            or bb.zmin < rve.min_point[2] - tol
-            or bb.zmax > rve.max_point[2] + tol
+            xmin < rve.min_point[0] - tol
+            or xmax > rve.max_point[0] + tol
+            or ymin < rve.min_point[1] - tol
+            or ymax > rve.max_point[1] + tol
+            or zmin < rve.min_point[2] - tol
+            or zmax > rve.max_point[2] + tol
         ):
             return False
     return True
@@ -180,7 +178,7 @@ def test_periodic_split_conserves_volume_and_stays_inside_rve(
 
     phase = _generate_sphere(x=x, y=y, z=z, rve=rve)
 
-    assert len(phase.solids) == expected_parts
+    assert len(phase.pieces) == expected_parts
     assert _all_solids_inside(phase, rve), (
         f"At least one fragment lies outside the RVE for seed ({x}, {y}, {z}); "
         "this typically means a translate(...) call moved the wrong half."

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -1,4 +1,11 @@
-"""Test for the phase module."""
+"""Tests for the Phase 2.0 module.
+
+Phase is now field-first (implicit-first) with CAD as an optional view.
+Construction goes through ``Phase.from_cad`` for CAD-backed phases and
+``Phase.from_shape`` for field-backed ones.  Transforms are immutable —
+``translated`` / ``scaled`` / ``tiled`` return new :class:`Phase`
+instances rather than mutating in place.
+"""
 
 import numpy as np
 
@@ -9,110 +16,129 @@ from microgen.shape import Box, Ellipsoid, Sphere
 
 
 def test_phase_sphere_rasterize_must_have_correct_number_of_solids() -> None:
-    """Rasterize Sphere by 3x3x3 grid must have 27 solids."""
+    """Rasterize Sphere by 3x3x3 grid must have 27 phases / 27 sub-solids."""
     rve = Rve(dim=1)
     sphere = Sphere(radius=0.5).generate_cad()
     grid = [3 for _ in range(3)]
 
-    phase = Phase(shape=sphere)
-    phases = phase.rasterize(rve=rve, grid=grid)
+    phase = Phase.from_cad(sphere)
+    phases = raster_phase(phase=phase, rve=rve, grid=grid)
     raster = raster_phase(phase=phase, rve=rve, grid=grid, phase_per_raster=False)
 
     assert len(phases) == np.prod(grid)
-    assert len(phases) == len(raster.solids)
+    assert len(raster.cad.solids()) == np.prod(grid)
 
 
 def test_phase_rasterize_phase_per_raster_should_return_the_right_object() -> None:
-    """Test the Phase class with a shape."""
+    """Test rastering via the operations free function."""
     rve = Rve(dim=1)
     sphere = Sphere(radius=0.5).generate_cad()
-    phase = Phase(shape=sphere)
+    phase = Phase.from_cad(sphere)
 
     grid = [3, 3, 3]
-    phases = phase.rasterize(rve, grid, phase_per_raster=True)
+    phases = raster_phase(phase=phase, rve=rve, grid=grid, phase_per_raster=True)
     assert isinstance(phases, list)
     assert len(phases) == np.prod(grid)
 
     grid = [2, 2, 2]
-    phase.rasterize(rve, grid, phase_per_raster=False)
-    assert len(phase.solids) == np.prod(grid)
+    rastered = raster_phase(phase=phase, rve=rve, grid=grid, phase_per_raster=False)
+    assert len(rastered.cad.solids()) == np.prod(grid)
 
 
-def test_phase_repeat_should_repeat_the_shape_in_the_rve() -> None:
-    """Test the Phase class with a shape."""
+def test_phase_tiled_should_repeat_the_shape_in_the_rve() -> None:
+    """Phase.tiled returns a new Phase with the geometry tiled on a grid."""
     rve = Rve(dim=1)
     box = Box(dim=(1.0, 1.0, 1.0)).generate_cad()
     volume_before = box.volume()
-    phase = Phase(shape=box)
+    phase = Phase.from_cad(box)
 
     repeat = (1, 2, 1)
-    phase.repeat(rve, grid=repeat)
-    assert len(phase.solids) == np.prod(repeat)
-    assert phase.shape.volume() == 2.0 * volume_before
+    tiled = phase.tiled(rve, grid=repeat)
+    assert len(tiled.cad.solids()) == np.prod(repeat)
+    assert np.isclose(tiled.cad.volume(), 2.0 * volume_before)
 
 
-def test_phase_rescale_should_change_the_size_of_the_shape() -> None:
-    """Test the Phase class with a shape."""
+def test_phase_scaled_should_change_the_size_of_the_shape() -> None:
+    """Phase.scaled returns a new Phase with cubed volume."""
     radius = 1.0
     scale = 1.5
-    phase = Phase(shape=Sphere(radius=radius).generate_cad())
-    volume_before = phase.shape.volume()
-    phase.rescale(scale)
-    assert np.isclose(phase.shape.volume(), volume_before * scale**3, rtol=1e-2)
+    phase = Phase.from_cad(Sphere(radius=radius).generate_cad())
+    volume_before = phase.cad.volume()
+    scaled = phase.scaled(scale)
+    assert np.isclose(scaled.cad.volume(), volume_before * scale**3, rtol=1e-2)
 
 
-def test_phase_translate_should_shift_centers_corresponding_to_the_translation() -> (
-    None
-):
-    """Test the Phase class with a shape."""
+def test_phase_translated_should_shift_centers() -> None:
+    """Phase.translated returns a new Phase with the COM shifted."""
     center = (1.0, 0.5, -0.5)
-    phase = Phase(
-        shape=Ellipsoid(center=center, radii=(0.15, 0.31, 0.4)).generate_cad()
+    phase = Phase.from_cad(
+        Ellipsoid(center=center, radii=(0.15, 0.31, 0.4)).generate_cad()
     )
-    phase.translate((1, 0, 0))
-    assert np.allclose(phase.center_of_mass, (2.0, 0.5, -0.5), rtol=1e-4)
-    phase.translate(np.array([0, 1, 1]))
-    assert np.allclose(phase.center_of_mass, (2.0, 1.5, 0.5), rtol=1e-4)
+    moved = phase.translated((1, 0, 0))
+    assert np.allclose(moved.center_of_mass, (2.0, 0.5, -0.5), rtol=1e-4)
+    moved2 = moved.translated(np.array([0, 1, 1]))
+    assert np.allclose(moved2.center_of_mass, (2.0, 1.5, 0.5), rtol=1e-4)
 
 
 def test_phase_center_of_mass_should_return_the_right_values() -> None:
-    """Test the Phase class with a shape."""
+    """``phase.center_of_mass`` is the BREP volumetric COM."""
     center = (1.0, 0.5, -0.5)
-    phase = Phase(
-        shape=Ellipsoid(center=center, radii=(0.15, 0.31, 0.4)).generate_cad()
+    phase = Phase.from_cad(
+        Ellipsoid(center=center, radii=(0.15, 0.31, 0.4)).generate_cad()
     )
     assert np.allclose(phase.center_of_mass, center, rtol=1e-4)
-    assert np.allclose(
-        phase.get_center_of_mass(compute=False),
-        phase.center_of_mass,
-        rtol=1e-4,
-    )
+    # Cached: accessing twice yields the same array object.
+    assert phase.center_of_mass is phase.center_of_mass
 
 
 def test_phase_inertia_matrix_should_return_the_right_values() -> None:
-    """Test the Phase class with a shape."""
+    """Inertia tensor of a uniform sphere is ``(2/5) m R²`` on the diagonal."""
     radius = 1.5
-    phase = Phase(shape=Sphere(radius=radius).generate_cad())
+    phase = Phase.from_cad(Sphere(radius=radius).generate_cad())
     assert np.allclose(
         phase.inertia_matrix,
-        np.diag([phase.shape.volume() * 2 / 5 * radius**2] * 3),
+        np.diag([phase.cad.volume() * 2 / 5 * radius**2] * 3),
     )
-    assert np.allclose(phase.get_inertia_matrix(compute=False), phase.inertia_matrix)
+    # Cached.
+    assert phase.inertia_matrix is phase.inertia_matrix
 
 
-def test_phase_solids_and_shape_properties_should_return_the_right_values() -> None:
-    """Test the Phase class with a shape."""
+def test_phase_cad_and_pieces_properties() -> None:
+    """``phase.cad`` exposes the CAD shape; ``phase.pieces`` enumerates solids."""
     ellipsoid = Ellipsoid(radii=(0.15, 0.31, 0.4)).generate_cad()
-    phase = Phase(shape=ellipsoid)
-    # Phase.solids returns raw TopoDS_Solid objects; identity-by-`==` doesn't
-    # apply, so check topological sameness against the wrapped solid instead.
-    assert len(phase.solids) == 1
-    assert phase.solids[0].IsSame(ellipsoid.wrapped)
-    assert phase.shape is ellipsoid
+    phase = Phase.from_cad(ellipsoid)
+    assert phase.cad is ellipsoid
+    pieces = phase.pieces
+    assert len(pieces) == 1
+    # The Piece carries its CAD payload.
+    assert pieces[0].cad is not None
+    assert pieces[0].volume > 0.0
 
 
-def test_phase_empty_should_have_empty_shape_and_solids() -> None:
-    """Test the Phase class with no shape."""
+def test_phase_empty_is_reported_as_such() -> None:
+    """``Phase()`` (no field/cad/mesh) is empty."""
     void_phase = Phase()
-    assert void_phase.shape is None
-    assert void_phase.solids == []
+    assert void_phase.is_empty
+    assert void_phase.field is None
+    assert void_phase.bounds is None
+
+
+def test_phase_from_shape_field_backed() -> None:
+    """``Phase.from_shape`` builds a field-backed phase from an implicit Shape."""
+    sphere = Sphere(radius=0.5)
+    phase = Phase.from_shape(sphere)
+    assert phase.field is not None
+    assert phase.bounds is not None
+    # Center of mass via grid quadrature on a centered sphere ≈ origin.
+    assert np.allclose(phase.center_of_mass, (0.0, 0.0, 0.0), atol=2e-2)
+    # The sphere is one connected piece.
+    assert len(phase.pieces) == 1
+
+
+def test_phase_from_shape_propagates_period() -> None:
+    """When the source Shape has a period, the Phase carries it."""
+    from microgen import Tpms, surface_functions
+
+    tpms = Tpms(surface_function=surface_functions.gyroid, offset=0.5, cell_size=1.0)
+    phase = Phase.from_shape(tpms)
+    assert phase.period == (1.0, 1.0, 1.0)

--- a/tests/test_phase_pieces.py
+++ b/tests/test_phase_pieces.py
@@ -1,0 +1,82 @@
+"""Tests for the ``Phase.pieces`` invariant — the "collection of sub-pieces".
+
+A :class:`Phase` is conceptually "one labelled material region", but
+practically it may split into multiple sub-pieces under periodicity or
+rasterisation.  :attr:`Phase.pieces` surfaces that structure uniformly
+across backends:
+
+- field-backed: ``scipy.ndimage.label`` on ``{field < iso}``.
+- CAD-backed: one :class:`Piece` per ``TopoDS_Solid``.
+"""
+
+import numpy as np
+
+from microgen import Phase, Sphere
+from microgen.phase import Piece
+from microgen.shape.implicit_ops import union
+
+# ruff: noqa: S101
+
+
+def test_pieces_field_single_sphere() -> None:
+    """A single sphere has exactly one piece."""
+    phase = Phase.from_shape(Sphere(radius=0.4))
+    pieces = phase.pieces
+    assert len(pieces) == 1
+    p = pieces[0]
+    assert isinstance(p, Piece)
+    assert p.voxel_mask is not None
+    assert p.cad is None
+    # The volume estimate is correct up to grid resolution.
+    expected = (4.0 / 3.0) * np.pi * 0.4**3
+    assert np.isclose(p.volume, expected, rtol=0.05)
+
+
+def test_pieces_field_two_disjoint_spheres() -> None:
+    """Two disjoint spheres produce two connected components.
+
+    Built by SDF union — the union field is negative inside *either*
+    sphere; the two solid regions are spatially disjoint, so
+    ``scipy.ndimage.label`` yields two components.
+    """
+    a = Sphere(center=(-0.6, 0.0, 0.0), radius=0.2)
+    b = Sphere(center=(0.6, 0.0, 0.0), radius=0.2)
+    merged = union(a, b)
+    # The unioned shape's auto-bounds is the AABB of the two — explicitly
+    # bound the phase to span both spheres.
+    phase = Phase.from_shape(merged, bounds=(-1.0, 1.0, -0.4, 0.4, -0.4, 0.4))
+    pieces = phase.pieces
+    assert len(pieces) == 2
+    coms = sorted(p.com[0] for p in pieces)
+    assert np.isclose(coms[0], -0.6, atol=0.05)
+    assert np.isclose(coms[1], 0.6, atol=0.05)
+
+
+def test_pieces_cad_single_sphere() -> None:
+    """A CAD-backed sphere has one piece carrying a CadShape payload."""
+    cad = Sphere(radius=0.5).generate_cad()
+    phase = Phase.from_cad(cad)
+    pieces = phase.pieces
+    assert len(pieces) == 1
+    assert pieces[0].cad is not None
+    assert pieces[0].voxel_mask is None
+
+
+def test_pieces_cached() -> None:
+    """``phase.pieces`` is a ``@cached_property`` — second access is the same list."""
+    phase = Phase.from_shape(Sphere(radius=0.4))
+    assert phase.pieces is phase.pieces
+
+
+def test_phase_translated_preserves_period_and_invalidates_cache() -> None:
+    """``translated()`` returns a new Phase — pieces and COM are recomputed."""
+    a = Sphere(center=(-0.6, 0.0, 0.0), radius=0.2)
+    b = Sphere(center=(0.6, 0.0, 0.0), radius=0.2)
+    merged = union(a, b)
+    phase = Phase.from_shape(merged, bounds=(-1.0, 1.0, -0.4, 0.4, -0.4, 0.4))
+    moved = phase.translated((1.0, 0.0, 0.0))
+    # New Phase => caches independent; both still report 2 pieces.
+    assert len(moved.pieces) == 2
+    shifts = sorted(p.com[0] for p in moved.pieces)
+    assert np.isclose(shifts[0], -0.6 + 1.0, atol=0.05)
+    assert np.isclose(shifts[1], 0.6 + 1.0, atol=0.05)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -29,7 +29,7 @@ def test_operations() -> None:
     """Test operations on shapes."""
     elem = microgen.Box(center=(0.5, 0.5, 0.5), dim=(1, 1, 1))
     shape1 = elem.generate_cad()
-    phase1 = microgen.Phase(shape=shape1)
+    phase1 = microgen.Phase.from_cad(shape1)
 
     elem = microgen.Box(center=(0, 0, 0), dim=(0.5, 0.5, 0.5))
     shape2 = elem.generate_cad()


### PR DESCRIPTION
This pull request introduces a new CAD backend for the project, replacing CadQuery with direct OCP (OpenCASCADE) calls through the new `microgen.cad` subpackage. The changes refactor example scripts to use the new CAD interface and add a comprehensive set of CAD utilities and primitives. The update also ensures that the CAD backend is an optional dependency, loaded only when needed, and provides user-friendly error messages if the dependency is missing.

The most important changes are:

**Introduction of the new CAD backend:**

* Added the `microgen.cad` subpackage, which provides a direct OCP-based CAD backend as a replacement for CadQuery. This includes a new `CadShape` wrapper class, primitive shape builders, STEP file I/O, and various CAD utility functions, all re-exported through `microgen/cad/__init__.py`.
* Implemented a user-friendly install gate (`require_cad`) in `microgen/cad/_install.py` to check for the optional OCP dependency and provide clear installation instructions if it's missing.

**CAD primitives and utility functions:**

* Added a suite of free functions in `microgen/cad/primitives.py` for creating core parametric primitives (box, sphere, cylinder, capsule, ellipsoid, polyhedron, extruded polygon), all returning `CadShape` instances.
* Added STEP file import support via `import_step` in `microgen/cad/io.py`, complementing export methods now available on `CadShape`.

**Refactoring of example scripts:**

* Updated all example scripts to use the new `Phase.from_cad` constructor instead of `Phase(shape=...)`, and to use `.cad` (instead of `.shape`) for downstream CAD operations and exports. This ensures compatibility with the new backend and makes use of the new `CadShape` interface. [[1]](diffhunk://#diff-c85d221f917ad7b333d541e3f75f2e6c2c15b57bdbeceac24f6b7266853c4c6bL11-R14) [[2]](diffhunk://#diff-978b51aa7ab24166c30fa5c54dd1c8de87ec9fe9084d4b9f9d165f11f201b2ccL42-R42) [[3]](diffhunk://#diff-5e21a0efbb994c431575eb0b90e75c32d331518d8f3d5609d0ba96a4aec848f5L21-R23) [[4]](diffhunk://#diff-360f2813f747cf81ff092ac7f452140afb2b0e130535d3c4d5984280122a95adL41-R48) [[5]](diffhunk://#diff-28279b4e40cfe2ce4ef9aa42433513e870615bbfae00499a10947f2194c04984L74-R81) [[6]](diffhunk://#diff-dc3d861aa7b3cf496ea0f3eead0b9862a1a2867163724938f41eb9376f113125L38-R43)

These changes modernize the CAD foundation of the codebase, improve modularity and error handling, and pave the way for further CAD-related enhancements.