### PR TITLE
Feature/implicit voronoi lattice

### DIFF
--- a/microgen/phase.py
+++ b/microgen/phase.py
@@ -434,13 +434,27 @@ class Phase:
         return out
 
     def _pieces_from_field(self: Phase) -> list[Piece]:
-        from scipy.ndimage import center_of_mass, find_objects, label  # noqa: PLC0415
+        from scipy.ndimage import (  # noqa: PLC0415
+            center_of_mass,
+            find_objects,
+            generate_binary_structure,
+            label,
+        )
 
         sg = self.grid()
         res = self._resolution
         scalar = np.asarray(sg[_IMPLICIT_SCALAR]).reshape((res, res, res), order="F")
         inside = scalar < self._iso
-        labels, n_labels = label(inside)
+        # 26-connectivity (faces + edges + corners) — the physically correct
+        # notion of "connected solid region" for a sampled continuous field.
+        # scipy's default is 6-connectivity (faces only), which fragments
+        # convex polyhedra at sharp vertices: a corner voxel and its diagonal
+        # neighbors all sample slightly inside but only touch corner-to-corner,
+        # so 6-connectivity reports them as separate components.  Genuinely
+        # disjoint regions (e.g. periodic-split fragments) are separated by
+        # many voxels and remain distinct under any connectivity.
+        structure = generate_binary_structure(3, 3)
+        labels, n_labels = label(inside, structure=structure)
         if n_labels == 0:
             return []
 

--- a/microgen/shape/polyhedron.py
+++ b/microgen/shape/polyhedron.py
@@ -30,6 +30,16 @@ Face = dict[str, list[int]]
 class Polyhedron(Shape):
     """Class to generate a Polyhedron with a given set of faces and vertices.
 
+    The implicit field is the half-space intersection SDF for a **convex**
+    polyhedron: ``f(p) = max_k (n_k · (p - c_k))``, where ``n_k`` is the
+    outward unit normal of face ``k`` and ``c_k`` its centroid.  Points
+    inside all half-spaces satisfy ``f(p) < 0``.  Voronoi cells produced
+    by Neper are convex by construction, which is the primary use case.
+
+    For non-convex polyhedra the implicit field is meaningless; use
+    :meth:`generate_cad` / :meth:`generate_surface_mesh` instead (those
+    work from the explicit face list).
+
     .. jupyter-execute::
        :hide-code:
 
@@ -72,6 +82,86 @@ class Polyhedron(Shape):
         self.faces_ixs = [face["vertices"] for face in self.dic["faces"]]
         for ixs in self.faces_ixs:
             ixs.append(ixs[0])
+
+        self._setup_frep_field()
+
+    def _setup_frep_field(self: Polyhedron) -> None:
+        """Build the convex-polyhedron half-space SDF in world coordinates.
+
+        Bakes the ``center`` translation and ``orientation`` rotation into
+        the cached face normals/centroids so the implicit ``_func`` does no
+        per-call transform.  Also derives ``_bounds`` from the world-frame
+        vertex AABB.
+        """
+        verts_local = np.asarray(self.dic["vertices"], dtype=np.float64)
+        rot = self.orientation.as_matrix()
+        cx, cy, cz = (float(c) for c in self.center)
+        # World-frame vertices: rotate about origin, then translate to center.
+        verts_world = verts_local @ rot.T + np.array([cx, cy, cz])
+        # Anchor for outward-orientation flip — the centroid of the convex
+        # hull is strictly interior, so any face normal that *should* be
+        # outward gives a positive ``n · (face_centroid - poly_centroid)``.
+        poly_centroid = verts_world.mean(axis=0)
+
+        normals: list[np.ndarray] = []
+        centroids: list[np.ndarray] = []
+        for ixs in self.faces_ixs:
+            # ``ixs`` is closed (last == first); strip the duplicate.
+            face_verts = verts_world[np.asarray(ixs[:-1], dtype=np.int64)]
+            if len(face_verts) < 3:
+                continue
+            edge1 = face_verts[1] - face_verts[0]
+            edge2 = face_verts[2] - face_verts[0]
+            n = np.cross(edge1, edge2)
+            n_len = float(np.linalg.norm(n))
+            if n_len == 0.0:
+                continue
+            n = n / n_len
+            face_centroid = face_verts.mean(axis=0)
+            # Flip if the cross-product convention pointed inward.
+            if np.dot(n, face_centroid - poly_centroid) < 0.0:
+                n = -n
+            normals.append(n)
+            centroids.append(face_centroid)
+
+        if not normals:
+            return  # degenerate polyhedron — leave _func unset
+
+        normals_arr = np.asarray(normals, dtype=np.float64)
+        centroids_arr = np.asarray(centroids, dtype=np.float64)
+        n_dot_c = (normals_arr * centroids_arr).sum(axis=1)
+
+        def _field(
+            x: np.ndarray,
+            y: np.ndarray,
+            z: np.ndarray,
+        ) -> np.ndarray:
+            x_arr = np.asarray(x)
+            shape = x_arr.shape
+            p = np.stack(
+                [x_arr.ravel(), np.asarray(y).ravel(), np.asarray(z).ravel()],
+                axis=-1,
+            )
+            # signed_d_k(p) = n_k · p − n_k · c_k; shape (N, K)
+            sd = p @ normals_arr.T - n_dot_c
+            return sd.max(axis=1).reshape(shape)
+
+        self._func = _field
+        margin = (
+            0.1
+            * float(np.linalg.norm(verts_world.max(axis=0) - verts_world.min(axis=0)))
+            or 0.1
+        )
+        vmin = verts_world.min(axis=0) - margin
+        vmax = verts_world.max(axis=0) + margin
+        self._bounds = (
+            float(vmin[0]),
+            float(vmax[0]),
+            float(vmin[1]),
+            float(vmax[1]),
+            float(vmin[2]),
+            float(vmax[2]),
+        )
 
     def generate_cad(self: Polyhedron, **_: KwargsGenerateType) -> CadShape:
         """Generate a polyhedron CAD shape (OCCT).  Requires the ``[cad]`` extra."""

--- a/microgen/shape/strut_lattice/abstract_lattice.py
+++ b/microgen/shape/strut_lattice/abstract_lattice.py
@@ -230,6 +230,44 @@ class AbstractLattice(Shape):
 
     cad_shape = property(generate_cad)
 
+    def generate_implicit(self: AbstractLattice) -> Shape:
+        """Return the lattice as a single composed implicit :class:`Shape`.
+
+        Builds ``(∪ struts ∪ joints) ∩ box`` by F-rep composition — every
+        primitive stays as a :class:`Cylinder` / :class:`Sphere` SDF;
+        nothing materialises BREP geometry.  Pair with :meth:`Phase.from_shape`
+        for an implicit-first pipeline (marching cubes mesh, ``pieces``
+        connectivity, grid-quadrature moments — no OCCT required).
+
+        For periodic boundary conditions, the existing CAD path
+        (:meth:`generate_cad`) does explicit ``periodic_split_and_translate``;
+        an implicit periodic-wrap is not produced here (struts that cross
+        the cell boundary are simply clipped by the bounding box).
+        """
+        from functools import reduce  # noqa: PLC0415
+        from operator import or_  # noqa: PLC0415
+
+        primitives: list[Shape] = [
+            Cylinder(
+                center=tuple(self.strut_centers[i]),
+                orientation=self.strut_rotations[i],
+                height=self.strut_heights[i],
+                radius=self.strut_radius,
+            )
+            for i in range(self.strut_number)
+        ]
+        if self.strut_joints:
+            primitives.extend(
+                Sphere(center=tuple(v), radius=self.strut_radius) for v in self.vertices
+            )
+
+        union = reduce(or_, primitives)
+        bounding_box = Box(
+            center=self.center,
+            dim=(self.cell_size, self.cell_size, self.cell_size),
+        )
+        return union & bounding_box
+
     def _generate_cad(self, **_: KwargsGenerateType) -> CadShape:
         """Generate a strut-based lattice CAD shape using the given parameters."""
         list_phases: list[Phase] = []

--- a/tests/test_implicit_voronoi_lattice.py
+++ b/tests/test_implicit_voronoi_lattice.py
@@ -1,0 +1,94 @@
+"""Tests for the implicit-first paths of :class:`Polyhedron` and lattices.
+
+A convex :class:`Polyhedron` exposes a half-space-intersection SDF
+``f(p) = max_k (n_k · (p - c_k))``, suitable for Voronoi cells.
+Strut-based lattices expose :meth:`AbstractLattice.generate_implicit`
+returning a single composed implicit :class:`Shape`.
+
+Both let downstream :class:`Phase` operate purely on the field —
+``Phase.from_shape(...)`` → marching-cubes mesh, grid-quadrature moments,
+``pieces`` connectivity — no OCCT required.
+"""
+
+import numpy as np
+
+from microgen import Cubic, Phase, Polyhedron
+from microgen.shape.shape import Shape
+
+# ruff: noqa: S101
+
+
+# ------------------------------------------------------------------ Polyhedron
+
+
+def test_polyhedron_default_tetrahedron_sdf_signs() -> None:
+    """SDF is negative at the centroid, ~0 at vertices, positive far outside."""
+    poly = Polyhedron()
+    f_center = float(
+        poly.evaluate(np.array([0.0]), np.array([0.0]), np.array([0.0]))[0]
+    )
+    f_vertex = float(
+        poly.evaluate(np.array([1.0]), np.array([1.0]), np.array([1.0]))[0]
+    )
+    f_far = float(poly.evaluate(np.array([5.0]), np.array([5.0]), np.array([5.0]))[0])
+    assert f_center < 0
+    assert abs(f_vertex) < 1e-6
+    assert f_far > 0
+
+
+def test_polyhedron_volume_via_phase_matches_analytic() -> None:
+    """Tetrahedron with vertices (±1,±1,±1)-pattern has volume 8/3."""
+    poly = Polyhedron()
+    phase = Phase.from_shape(poly, resolution=80)
+    total_vol = sum(p.volume for p in phase.pieces)
+    assert np.isclose(total_vol, 8.0 / 3.0, rtol=0.05)
+
+
+def test_polyhedron_phase_is_one_piece() -> None:
+    """A single convex polyhedron yields one connected component."""
+    poly = Polyhedron()
+    phase = Phase.from_shape(poly, resolution=50)
+    assert len(phase.pieces) == 1
+
+
+def test_polyhedron_translates_correctly() -> None:
+    """When ``center`` is non-zero, the field's COM matches the center."""
+    poly = Polyhedron(center=(2.0, -1.0, 0.5))
+    phase = Phase.from_shape(poly, resolution=50)
+    assert np.allclose(phase.center_of_mass, (2.0, -1.0, 0.5), atol=0.05)
+
+
+# ------------------------------------------------------------------ Lattice
+
+
+def test_cubic_lattice_implicit_returns_shape() -> None:
+    """``generate_implicit()`` returns a composed :class:`Shape`."""
+    lat = Cubic(strut_radius=0.05)
+    implicit = lat.generate_implicit()
+    assert isinstance(implicit, Shape)
+    assert implicit.func is not None
+    assert implicit.bounds is not None
+
+
+def test_cubic_lattice_implicit_one_connected_piece() -> None:
+    """The 12 edge struts share corner endpoints — one connected piece."""
+    lat = Cubic(strut_radius=0.05)
+    phase = Phase.from_shape(lat.generate_implicit(), resolution=60)
+    assert len(phase.pieces) == 1
+
+
+def test_cubic_lattice_implicit_volume_approaches_cad() -> None:
+    """Grid quadrature on the implicit lattice converges toward the CAD volume."""
+    lat = Cubic(strut_radius=0.05)
+    phase = Phase.from_shape(lat.generate_implicit(), resolution=100)
+    grid_vol = sum(p.volume for p in phase.pieces)
+    cad_vol = lat.cad_shape.volume()
+    # 100³ quadrature on a 0.05-radius lattice: expect ~5% error.
+    assert np.isclose(grid_vol, cad_vol, rtol=0.10)
+
+
+def test_cubic_lattice_implicit_center_of_mass_at_origin() -> None:
+    """Symmetric cubic cell — COM should be near the cell center."""
+    lat = Cubic(strut_radius=0.05)
+    phase = Phase.from_shape(lat.generate_implicit(), resolution=60)
+    assert np.allclose(phase.center_of_mass, (0.0, 0.0, 0.0), atol=1e-2)


### PR DESCRIPTION
This pull request introduces a new CAD backend for microgen, replacing CadQuery with direct OCP (OCCT) calls, and updates example scripts to use the new backend API. The main changes include adding a well-structured `microgen.cad` package with clear separation of concerns, providing factory functions for CAD primitives, and updating all example usages to the new `Phase.from_cad` and `.cad` API. This modernizes the codebase, improves modularity, and ensures a smoother user experience for CAD operations.

**CAD Backend Introduction and API Modernization**

* Added a new `microgen.cad` subpackage as a direct OCCT backend, replacing CadQuery. This includes a comprehensive `__init__.py` that re-exports all public symbols, ensuring backward compatibility for imports.
* Added an install gate (`_install.py`) with a `require_cad()` function to lazily check for the OCP dependency and provide user-friendly error messages if missing.
* Added a standalone STEP file import function in `io.py` for reading CAD files, with export methods now living on the `CadShape` class.
* Added a set of factory functions in `primitives.py` for creating basic CAD shapes (box, sphere, cylinder, capsule, ellipsoid, polyhedron, extruded polygon) as `CadShape` instances, serving as the new backend for implicit shape classes.

**Example Script Updates**

* Updated all example scripts under `examples/3Doperations` and `examples/Lattices` to use `Phase.from_cad` instead of `Phase(shape=...)`, and to access the CAD object via `.cad` instead of `.shape`. This ensures compatibility with the new backend and API. [[1]](diffhunk://#diff-c85d221f917ad7b333d541e3f75f2e6c2c15b57bdbeceac24f6b7266853c4c6bL11-R14) [[2]](diffhunk://#diff-978b51aa7ab24166c30fa5c54dd1c8de87ec9fe9084d4b9f9d165f11f201b2ccL42-R42) [[3]](diffhunk://#diff-5e21a0efbb994c431575eb0b90e75c32d331518d8f3d5609d0ba96a4aec848f5L21-R23) [[4]](diffhunk://#diff-360f2813f747cf81ff092ac7f452140afb2b0e130535d3c4d5984280122a95adL41-R48) [[5]](diffhunk://#diff-28279b4e40cfe2ce4ef9aa42433513e870615bbfae00499a10947f2194c04984L74-R81) [[6]](diffhunk://#diff-dc3d861aa7b3cf496ea0f3eead0b9862a1a2867163724938f41eb9376f113125L38-R43)

These changes collectively provide a more robust, modular, and user-friendly CAD interface for microgen, with improved error handling and future extensibility.