### PR TITLE
Extract try_make_solid into periodic_shell

### DIFF
--- a/microgen/shape/periodic_shell.py
+++ b/microgen/shape/periodic_shell.py
@@ -121,4 +121,68 @@ def mesh_to_periodic_shell(
     return _CadShape(sewing.SewedShape())
 
 
-__all__ = ["mesh_to_periodic_shell"]
+def try_make_solid(shape: CadShape) -> CadShape:
+    """Best-effort upgrade of a sewn shell (or compound of shells) to a Solid.
+
+    For each closed shell, builds a ``TopoDS_Solid`` via
+    :class:`OCP.BRepBuilderAPI.BRepBuilderAPI_MakeSolid` and reorients via
+    :func:`OCP.BRepLib.BRepLib.OrientClosedSolid_s` so the volume encloses
+    the right region (without this, sewing-from-mesh can produce an
+    inside-out solid whose ``VolumeProperties`` reads
+    ``cube_volume - actual_volume``).
+
+    The input is the output of :func:`mesh_to_periodic_shell`; it may be:
+
+    - a single ``TopoDS_Shell`` — upgraded directly to a Solid (or returned
+      unchanged if OCCT refuses the conversion).
+    - a Compound of disjoint shells (one per closed component of the
+      periodic mesh) — each shell becomes its own Solid; multiple solids
+      are fused into one ``TopoDS_Compound``.
+
+    Shared by :class:`microgen.shape.tpms.Tpms` and
+    :class:`microgen.shape.spinodoid.Spinodoid`.
+
+    Requires the optional ``[cad]`` install extra.
+    """
+    from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeSolid  # noqa: PLC0415
+    from OCP.BRepLib import BRepLib  # noqa: PLC0415
+    from OCP.TopAbs import TopAbs_SHELL  # noqa: PLC0415
+    from OCP.TopExp import TopExp_Explorer  # noqa: PLC0415
+
+    from microgen.cad import CadShape as _CadShape  # noqa: PLC0415
+    from microgen.cad.shape import _topods_cast  # noqa: PLC0415
+    from microgen.operations import fuse_shapes  # noqa: PLC0415
+
+    cast_shell = _topods_cast("Shell")
+    cast_solid = _topods_cast("Solid")
+
+    def _make_solid(shell_shape) -> CadShape | None:
+        try:
+            solid = BRepBuilderAPI_MakeSolid(shell_shape).Solid()
+        except (ValueError, RuntimeError):
+            return None
+        BRepLib.OrientClosedSolid_s(cast_solid(solid))
+        return _CadShape(solid)
+
+    wrapped = shape.wrapped
+    if wrapped.ShapeType() == TopAbs_SHELL:
+        built = _make_solid(cast_shell(wrapped))
+        return built if built is not None else shape
+
+    # Compound: extract shells, build one Solid per closed shell, fuse.
+    exp = TopExp_Explorer(wrapped, TopAbs_SHELL)
+    solids: list[CadShape] = []
+    while exp.More():
+        built = _make_solid(cast_shell(exp.Current()))
+        if built is not None:
+            solids.append(built)
+        exp.Next()
+
+    if not solids:
+        return shape
+    if len(solids) == 1:
+        return solids[0]
+    return fuse_shapes(solids, retain_edges=False)
+
+
+__all__ = ["mesh_to_periodic_shell", "try_make_solid"]

--- a/microgen/shape/spinodoid.py
+++ b/microgen/shape/spinodoid.py
@@ -29,7 +29,7 @@ import pyvista as pv
 
 from ..operations import rotate
 from ._frep_grf import _FrepGRF, _normalize_cell_size, compute_threshold_for_porosity
-from .periodic_shell import mesh_to_periodic_shell
+from .periodic_shell import mesh_to_periodic_shell, try_make_solid
 from .shape import Shape
 
 if TYPE_CHECKING:
@@ -263,57 +263,10 @@ class Spinodoid(Shape):
         pts = np.asarray(mesh.points, dtype=np.float64)
         tris = mesh.faces.reshape(-1, 4)[:, 1:].astype(np.int64)
 
-        shape = _try_make_solid(mesh_to_periodic_shell(pts, tris, self._bounds))
+        shape = try_make_solid(mesh_to_periodic_shell(pts, tris, self._bounds))
         shape = rotate(obj=shape, center=(0, 0, 0), rotation=self.orientation)
         shape = shape.translate(self.center)
         # Fallback for OCCT Volume() on solids it flags invalid (rigid transforms preserve volume).
         with contextlib.suppress(AttributeError, ValueError):
             shape._mesh_volume = float(abs(self.grid_solid.volume))
         return shape
-
-
-def _try_make_solid(shape: CadShape) -> CadShape:
-    """Best-effort upgrade of a sewn shell (or compound of shells) to a Solid.
-
-    Mirrors :meth:`microgen.Tpms._try_make_solid` (tpms.py:1006). For each
-    closed shell, builds a ``TopoDS_Solid`` via ``BRepBuilderAPI_MakeSolid``
-    and reorients via ``BRepLib.OrientClosedSolid_s`` so the volume encloses
-    the right region. Multiple disjoint shells fuse into a Compound.
-    """
-    from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeSolid
-    from OCP.BRepLib import BRepLib
-    from OCP.TopAbs import TopAbs_SHELL
-    from OCP.TopExp import TopExp_Explorer
-
-    from microgen.cad import CadShape as _CadShape
-    from microgen.cad.shape import _topods_cast
-    from microgen.operations import fuse_shapes
-
-    cast_shell = _topods_cast("Shell")
-    cast_solid = _topods_cast("Solid")
-
-    def _make_solid(shell) -> CadShape | None:
-        try:
-            solid = BRepBuilderAPI_MakeSolid(shell).Solid()
-        except (ValueError, RuntimeError):
-            return None
-        BRepLib.OrientClosedSolid_s(cast_solid(solid))
-        return _CadShape(solid)
-
-    wrapped = shape.wrapped
-    if wrapped.ShapeType() == TopAbs_SHELL:
-        built = _make_solid(cast_shell(wrapped))
-        return built if built is not None else shape
-
-    exp = TopExp_Explorer(wrapped, TopAbs_SHELL)
-    solids: list[CadShape] = []
-    while exp.More():
-        built = _make_solid(cast_shell(exp.Current()))
-        if built is not None:
-            solids.append(built)
-        exp.Next()
-    if not solids:
-        return shape
-    if len(solids) == 1:
-        return solids[0]
-    return fuse_shapes(solids, retain_edges=False)

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -27,6 +27,7 @@ from scipy.optimize import root_scalar
 from microgen.operations import rotate
 
 from ._types import BoundsType, Field
+from .periodic_shell import mesh_to_periodic_shell, try_make_solid
 from .shape import Shape, ShellCreationError
 
 if TYPE_CHECKING:
@@ -697,8 +698,6 @@ class Tpms(Shape):
         which sews TPMS-interior triangles with per-face cap planes into a
         single closed shell (see that function's docstring for details).
         """
-        from .periodic_shell import mesh_to_periodic_shell  # noqa: PLC0415
-
         if not mesh.is_all_triangles:
             mesh.triangulate(inplace=True)
         pts = np.asarray(mesh.points, dtype=np.float64)
@@ -915,8 +914,6 @@ class Tpms(Shape):
         # a fallback when OCCT flags the solid invalid (self-intersecting or
         # non-manifold from raw marching-cubes — happens for skeletals at
         # offset=0 where the iso-surface coincides with the cell boundary).
-        from .periodic_shell import try_make_solid  # noqa: PLC0415
-
         shape = try_make_solid(self._mesh_to_periodic_shell(mesh))
         shape = rotate(obj=shape, center=(0, 0, 0), rotation=self.orientation)
         shape = shape.translate(self.center)

--- a/microgen/shape/tpms.py
+++ b/microgen/shape/tpms.py
@@ -24,7 +24,7 @@ import numpy.typing as npt
 import pyvista as pv
 from scipy.optimize import root_scalar
 
-from microgen.operations import fuse_shapes, rotate
+from microgen.operations import rotate
 
 from ._types import BoundsType, Field
 from .shape import Shape, ShellCreationError
@@ -915,62 +915,14 @@ class Tpms(Shape):
         # a fallback when OCCT flags the solid invalid (self-intersecting or
         # non-manifold from raw marching-cubes — happens for skeletals at
         # offset=0 where the iso-surface coincides with the cell boundary).
-        shape = self._try_make_solid(self._mesh_to_periodic_shell(mesh))
+        from .periodic_shell import try_make_solid  # noqa: PLC0415
+
+        shape = try_make_solid(self._mesh_to_periodic_shell(mesh))
         shape = rotate(obj=shape, center=(0, 0, 0), rotation=self.orientation)
         shape = shape.translate(self.center)
         with contextlib.suppress(AttributeError, ValueError):
             shape._mesh_volume = float(abs(mesh.volume))
         return shape
-
-    @staticmethod
-    def _try_make_solid(shape: CadShape) -> CadShape:
-        """Best-effort upgrade of a sewn shell into a closed Solid.
-
-        Returns the original shape unchanged if the sewn result is a Compound
-        (multiple disjoint shells, can't be a single solid) or if OCCT refuses
-        the conversion. Reorients via :func:`BRepLib.OrientClosedSolid_s` so
-        that the resulting Solid encloses the right region (without this,
-        sewing-from-mesh can produce an inside-out solid whose
-        ``VolumeProperties`` reads ``cube_volume - actual_volume``).
-        """
-        from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeSolid
-        from OCP.BRepLib import BRepLib
-        from OCP.TopAbs import TopAbs_SHELL
-        from OCP.TopExp import TopExp_Explorer
-
-        from microgen.cad import CadShape as _CadShape
-        from microgen.cad.shape import _topods_cast
-
-        cast_shell = _topods_cast("Shell")
-        cast_solid = _topods_cast("Solid")
-
-        def _make_solid(shell_shape) -> CadShape | None:
-            try:
-                solid = BRepBuilderAPI_MakeSolid(shell_shape).Solid()
-            except (ValueError, RuntimeError):
-                return None
-            BRepLib.OrientClosedSolid_s(cast_solid(solid))
-            return _CadShape(solid)
-
-        wrapped = shape.wrapped
-        if wrapped.ShapeType() == TopAbs_SHELL:
-            built = _make_solid(cast_shell(wrapped))
-            return built if built is not None else shape
-
-        # Compound: extract Shells, build a Solid per closed shell, fuse.
-        exp = TopExp_Explorer(wrapped, TopAbs_SHELL)
-        solids: list[CadShape] = []
-        while exp.More():
-            built = _make_solid(cast_shell(exp.Current()))
-            if built is not None:
-                solids.append(built)
-            exp.Next()
-
-        if not solids:
-            return shape
-        if len(solids) == 1:
-            return solids[0]
-        return fuse_shapes(solids, retain_edges=False)
 
     def generate_surface_mesh(
         self: Tpms,


### PR DESCRIPTION
Add a centralized try_make_solid helper in microgen.shape.periodic_shell that upgrades sewn shells (or compounds of shells) into TopoDS_Solid(s), reorients enclosed volume, and fuses multiple solids when needed. Export the helper via __all__ and update Tpms and Spinodoid to reuse it (removing duplicated implementations). Also tidy related imports (remove now-unused fuse_shapes import in tpms). The helper uses OCP APIs and is shared by TPMS and spinodoid shape creation.